### PR TITLE
fix(day_handler): pass `notifyListeners` to `SchoolYearManager`

### DIFF
--- a/lib/src/model/date/day_handler.dart
+++ b/lib/src/model/date/day_handler.dart
@@ -29,7 +29,10 @@ class DayHandler with ChangeNotifier {
   DayHandler([SchoolYearManager? schoolYearManager]) {
     _dateTime = DateTime.now();
     this.schoolYearManager = schoolYearManager ??
-        SchoolYearManager(schoolYears: _defaultSchoolYears);
+        SchoolYearManager(
+          schoolYears: _defaultSchoolYears,
+          notifyExternalListeners: notifyListeners,
+        );
   }
 
   DateTime get dateTime => _dateTime;


### PR DESCRIPTION
Passing `notifyListeners` allows `SchoolYearManager` actions to properly notify `DayHandler`.