### PR TITLE
test(time_of_day_extension): add Comparable tests

### DIFF
--- a/lib/utils/time_of_day_extension.dart
+++ b/lib/utils/time_of_day_extension.dart
@@ -59,12 +59,12 @@ extension TimeOfDayExtension on TimeOfDay {
   // TODO(albertms10): remove when implemented in Flutter, https://github.com/flutter/flutter/pull/59981
   static int compare(TimeOfDay a, TimeOfDay b) => a.compareTo(b);
 
-  int get inMinutes => hour * TimeOfDay.minutesPerHour + minute;
+  int get _inMinutes => hour * TimeOfDay.minutesPerHour + minute;
 
   int compareTo(TimeOfDay? other) {
     if (other == null) return 1;
     if (other == this) return 0;
 
-    return inMinutes.compareTo(other.inMinutes);
+    return _inMinutes.compareTo(other._inMinutes);
   }
 }

--- a/test/time_of_day_extension_test.dart
+++ b/test/time_of_day_extension_test.dart
@@ -91,5 +91,57 @@ void main() {
         expect(const TimeOfDay(hour: 17, minute: 45).format24Hour(), '17:45');
       });
     });
+
+    // TODO(albertms10): remove when implemented in Flutter, https://github.com/flutter/flutter/pull/59981
+    group('Comparable<TimeOfDay>', () {
+      test('.compare', () {
+        expect(
+          TimeOfDayExtension.compare(
+            const TimeOfDay(hour: 0, minute: 0),
+            const TimeOfDay(hour: 0, minute: 0),
+          ),
+          0,
+        );
+      });
+
+      test('.compareTo', () {
+        expect(
+          [
+            const TimeOfDay(hour: 12, minute: 0),
+            const TimeOfDay(hour: 23, minute: 59),
+            const TimeOfDay(hour: 0, minute: 0),
+          ]..sort(),
+          [
+            const TimeOfDay(hour: 0, minute: 0),
+            const TimeOfDay(hour: 12, minute: 0),
+            const TimeOfDay(hour: 23, minute: 59),
+          ],
+        );
+
+        expect(const TimeOfDay(hour: 0, minute: 0).compareTo(null) > 0, true);
+
+        const zero = TimeOfDay(hour: 0, minute: 0);
+        expect(zero.compareTo(zero), 0);
+
+        expect(
+          const TimeOfDay(hour: 0, minute: 0)
+              .compareTo(const TimeOfDay(hour: 0, minute: 0)),
+          0,
+        );
+
+        expect(
+          [
+            const TimeOfDay(hour: 0, minute: 0),
+            const TimeOfDay(hour: 23, minute: 59),
+            const TimeOfDay(hour: 12, minute: 0),
+          ]..sort(),
+          [
+            const TimeOfDay(hour: 0, minute: 0),
+            const TimeOfDay(hour: 12, minute: 0),
+            const TimeOfDay(hour: 23, minute: 59),
+          ],
+        );
+      });
+    });
   });
 }

--- a/test/time_of_day_extension_test.dart
+++ b/test/time_of_day_extension_test.dart
@@ -94,23 +94,13 @@ void main() {
 
     // TODO(albertms10): remove when implemented in Flutter, https://github.com/flutter/flutter/pull/59981
     group('Comparable<TimeOfDay>', () {
-      test('.compare', () {
-        expect(
-          TimeOfDayExtension.compare(
-            const TimeOfDay(hour: 0, minute: 0),
-            const TimeOfDay(hour: 0, minute: 0),
-          ),
-          0,
-        );
-      });
-
       test('.compareTo', () {
         expect(
           [
             const TimeOfDay(hour: 12, minute: 0),
             const TimeOfDay(hour: 23, minute: 59),
             const TimeOfDay(hour: 0, minute: 0),
-          ]..sort(),
+          ]..sort(TimeOfDayExtension.compare),
           [
             const TimeOfDay(hour: 0, minute: 0),
             const TimeOfDay(hour: 12, minute: 0),
@@ -134,7 +124,7 @@ void main() {
             const TimeOfDay(hour: 0, minute: 0),
             const TimeOfDay(hour: 23, minute: 59),
             const TimeOfDay(hour: 12, minute: 0),
-          ]..sort(),
+          ]..sort(TimeOfDayExtension.compare),
           [
             const TimeOfDay(hour: 0, minute: 0),
             const TimeOfDay(hour: 12, minute: 0),


### PR DESCRIPTION
Test implementation for cfe1aba

Workaround until https://github.com/flutter/flutter/pull/59981 is included again.