### PR TITLE
chore(pubspec): replace unauthenticated `git://` protocol

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -426,7 +426,7 @@ packages:
       path: "plugins/window_size"
       ref: HEAD
       resolved-ref: "5c51870ced62a00e809ba4b81a846a052d241c9f"
-      url: "git://github.com/google/flutter-desktop-embedding.git"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
     source: git
     version: "0.1.0"
   xdg_directories:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   timer_builder: ^2.0.0
   window_size:
     git:
-      url: git://github.com/google/flutter-desktop-embedding.git
+      url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
 
 dev_dependencies:


### PR DESCRIPTION
[Flutter CI #245](https://github.com/albertms10/cabin_booking/runs/5964145908?check_suite_focus=true) failed on April 11, 2022

See [Improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github) article (September 1, 2021):

> _March 15, 2022_
> 
> **Changes made permanent.**
> We’ll permanently stop accepting DSA keys. RSA keys uploaded after the cut-off point above will work only with SHA-2 signatures (but again, RSA keys uploaded before this date will continue to work with SHA-1). The deprecated MACs, ciphers, and unencrypted Git protocol will be permanently disabled.
