### PR TITLE
refactor(booking): store start and end `DateTime`s instead of `TimeOfDay`s

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -8,17 +8,15 @@ import '../item.dart';
 
 abstract class _JsonFields {
   static const description = 'de';
-  static const date = 'd';
-  static const startTime = 'st';
-  static const endTime = 'et';
+  static const startDateTime = 'sd';
+  static const endDateTime = 'ed';
   static const isLocked = 'il';
 }
 
 class Booking extends Item {
   String? description;
-  DateTime? date;
-  TimeOfDay? startTime;
-  TimeOfDay? endTime;
+  DateTime? startDateTime;
+  DateTime? endDateTime;
   bool isLocked;
   String? cabinId;
 
@@ -29,9 +27,8 @@ class Booking extends Item {
   Booking({
     super.id,
     this.description,
-    this.date,
-    this.startTime,
-    this.endTime,
+    this.startDateTime,
+    this.endDateTime,
     this.isLocked = false,
     this.cabinId,
     this.recurringBookingId,
@@ -41,11 +38,11 @@ class Booking extends Item {
 
   Booking.from(super.other)
       : description = other[_JsonFields.description] as String?,
-        date = DateTime.tryParse(other[_JsonFields.date] as String),
-        startTime =
-            TimeOfDayExtension.tryParse(other[_JsonFields.startTime] as String),
-        endTime =
-            TimeOfDayExtension.tryParse(other[_JsonFields.endTime] as String),
+        startDateTime = DateTime.tryParse(
+          other[_JsonFields.startDateTime] as String? ?? '',
+        ),
+        endDateTime =
+            DateTime.tryParse(other[_JsonFields.endDateTime] as String? ?? ''),
         isLocked = other[_JsonFields.isLocked] as bool,
         super.from();
 
@@ -53,22 +50,24 @@ class Booking extends Item {
   Map<String, dynamic> toJson() => {
         ...super.toJson(),
         _JsonFields.description: description,
-        _JsonFields.date: date?.toIso8601String().split('T').first,
-        _JsonFields.startTime: startTime?.format24Hour(),
-        _JsonFields.endTime: endTime?.format24Hour(),
+        _JsonFields.startDateTime: startDateTime?.toUtc().toIso8601String(),
+        _JsonFields.endDateTime: endDateTime?.toUtc().toIso8601String(),
         _JsonFields.isLocked: isLocked,
       };
 
-  DateTime get startDateTime => date!.addTimeOfDay(startTime);
+  /// Alias for [startDateTime].
+  DateTime? get date => startDateTime;
 
-  DateTime get endDateTime => date!.addTimeOfDay(endTime);
+  TimeOfDay get startTime => TimeOfDay.fromDateTime(startDateTime!);
 
-  Duration get duration => endDateTime.difference(startDateTime);
+  TimeOfDay get endTime => TimeOfDay.fromDateTime(endDateTime!);
+
+  Duration get duration => endDateTime!.difference(startDateTime!);
 
   Map<TimeOfDay, Duration> get hoursSpan {
     final timeRanges = <TimeOfDay, Duration>{};
 
-    var runTime = startTime!;
+    var runTime = startTime;
     var runDuration = Duration.zero;
 
     while (runDuration < duration) {
@@ -78,7 +77,7 @@ class Booking extends Item {
       );
 
       final nextTime =
-          endTime!.difference(nextHour).isNegative ? endTime! : nextHour;
+          endTime.difference(nextHour).isNegative ? endTime : nextHour;
       final currentDuration = nextTime.difference(runTime);
 
       runDuration += currentDuration;
@@ -93,35 +92,35 @@ class Booking extends Item {
     return timeRanges;
   }
 
-  String get timeRange => '${startTime?.format24Hour()}'
-      '–${endTime?.format24Hour()}';
+  String get timeRange => '${startTime.format24Hour()}'
+      '–${endTime.format24Hour()}';
 
-  String get dateTimeRange => '${DateFormat.yMd().format(date!)} $timeRange';
+  String get dateTimeRange =>
+      '${DateFormat.yMd().format(startDateTime!)} $timeRange';
 
-  bool isOn(DateTime dateTime) => date?.isSameDateAs(dateTime) ?? false;
+  bool isOn(DateTime dateTime) =>
+      startDateTime?.isSameDateAs(dateTime) ?? false;
 
-  bool isBetween(DateRanger dateRange) => dateRange.includes(startDateTime);
+  bool isBetween(DateRanger dateRange) => dateRange.includes(startDateTime!);
 
   bool collidesWith(Booking booking) =>
-      startDateTime.isBefore(booking.endDateTime) &&
-      endDateTime.isAfter(booking.startDateTime);
+      startDateTime!.isBefore(booking.endDateTime!) &&
+      endDateTime!.isAfter(booking.startDateTime!);
 
   @override
   Booking copyWith({
     String? id,
     String? description,
-    DateTime? date,
-    TimeOfDay? startTime,
-    TimeOfDay? endTime,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
     bool? isLocked,
     String? cabinId,
   }) =>
       Booking(
         id: id ?? this.id,
         description: description ?? this.description,
-        date: date ?? this.date,
-        startTime: startTime ?? this.startTime,
-        endTime: endTime ?? this.endTime,
+        startDateTime: startDateTime ?? this.startDateTime,
+        endDateTime: endDateTime ?? this.endDateTime,
         isLocked: isLocked ?? this.isLocked,
         cabinId: cabinId ?? this.cabinId,
       );
@@ -129,9 +128,8 @@ class Booking extends Item {
   @override
   void replaceWith(covariant Booking item) {
     description = item.description;
-    date = item.date;
-    startTime = item.startTime;
-    endTime = item.endTime;
+    startDateTime = item.startDateTime;
+    endDateTime = item.endDateTime;
     isLocked = item.isLocked;
 
     super.replaceWith(item);
@@ -143,5 +141,5 @@ class Booking extends Item {
 
   @override
   int compareTo(covariant Booking other) =>
-      startDateTime.compareTo(other.startDateTime);
+      startDateTime!.compareTo(other.startDateTime!);
 }

--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -50,8 +50,8 @@ class Booking extends Item {
   Map<String, dynamic> toJson() => {
         ...super.toJson(),
         _JsonFields.description: description,
-        _JsonFields.startDateTime: startDateTime?.toUtc().toIso8601String(),
-        _JsonFields.endDateTime: endDateTime?.toUtc().toIso8601String(),
+        _JsonFields.startDateTime: startDateTime?.toIso8601String(),
+        _JsonFields.endDateTime: endDateTime?.toIso8601String(),
         _JsonFields.isLocked: isLocked,
       };
 

--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:flutter/material.dart';
 
 import 'booking.dart';
 
@@ -20,9 +19,8 @@ class RecurringBooking extends Booking {
   RecurringBooking({
     super.id,
     super.description,
-    super.date,
-    super.startTime,
-    super.endTime,
+    super.startDateTime,
+    super.endDateTime,
     super.isLocked,
     super.cabinId,
     this.periodicity = Periodicity.weekly,
@@ -64,9 +62,8 @@ class RecurringBooking extends Booking {
         super(
           id: booking.id,
           description: booking.description,
-          date: booking.date,
-          startTime: booking.startTime,
-          endTime: booking.endTime,
+          startDateTime: booking.startDateTime,
+          endDateTime: booking.endDateTime,
           isLocked: booking.isLocked,
           cabinId: booking.cabinId,
         );
@@ -130,9 +127,8 @@ class RecurringBooking extends Booking {
   Booking asBooking({bool linked = true}) => Booking(
         id: linked ? '$id-0' : (recurringBookingId ?? id),
         description: description,
-        date: date,
-        startTime: startTime,
-        endTime: endTime,
+        startDateTime: startDateTime,
+        endDateTime: endDateTime,
         isLocked: isLocked,
         cabinId: cabinId,
         recurringBookingId: linked ? id : null,
@@ -157,7 +153,10 @@ class RecurringBooking extends Booking {
       runDate = runDate.add(periodicityDuration);
 
       if (runDate.isBefore(recurringEndDate)) {
-        movedBooking = movedBooking.copyWith(date: runDate);
+        movedBooking = movedBooking.copyWith(
+          startDateTime: runDate,
+          endDateTime: runDate.add(duration),
+        );
         count++;
       }
     }
@@ -175,9 +174,8 @@ class RecurringBooking extends Booking {
   RecurringBooking copyWith({
     String? id,
     String? description,
-    DateTime? date,
-    TimeOfDay? startTime,
-    TimeOfDay? endTime,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
     bool? isLocked,
     String? cabinId,
     Periodicity? periodicity,
@@ -188,9 +186,8 @@ class RecurringBooking extends Booking {
       RecurringBooking(
         id: id ?? this.id,
         description: description ?? this.description,
-        date: date ?? this.date,
-        startTime: startTime ?? this.startTime,
-        endTime: endTime ?? this.endTime,
+        startDateTime: startDateTime ?? this.startDateTime,
+        endDateTime: endDateTime ?? this.endDateTime,
         isLocked: isLocked ?? this.isLocked,
         cabinId: cabinId ?? this.cabinId,
         periodicity: periodicity ?? this.periodicity,

--- a/lib/src/model/date/date_range_item.dart
+++ b/lib/src/model/date/date_range_item.dart
@@ -66,6 +66,9 @@ class DateRangeItem extends Item with DateRanger {
   int get hashCode => Object.hash(startDate, endDate);
 
   @override
-  int compareTo(covariant DateRangeItem other) =>
-      startDate!.compareTo(other.startDate!);
+  int compareTo(covariant DateRangeItem other) {
+    if (startDate == null || other.startDate == null) return 0;
+
+    return startDate!.compareTo(other.startDate!);
+  }
 }

--- a/lib/src/model/date/date_range_item.dart
+++ b/lib/src/model/date/date_range_item.dart
@@ -66,9 +66,6 @@ class DateRangeItem extends Item with DateRanger {
   int get hashCode => Object.hash(startDate, endDate);
 
   @override
-  int compareTo(covariant DateRangeItem other) {
-    if (startDate == null || other.startDate == null) return 0;
-
-    return startDate!.compareTo(other.startDate!);
-  }
+  int compareTo(covariant DateRangeItem other) =>
+      startDate!.compareTo(other.startDate!);
 }

--- a/lib/widgets/booking/booking_card.dart
+++ b/lib/widgets/booking/booking_card.dart
@@ -24,7 +24,7 @@ class BookingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isBeforeNow = booking.endDateTime.isBefore(DateTime.now());
+    final isBeforeNow = booking.endDateTime!.isBefore(DateTime.now());
 
     return TimerBuilder.periodic(
       const Duration(minutes: 1),

--- a/lib/widgets/booking/booking_floating_action_button.dart
+++ b/lib/widgets/booking/booking_floating_action_button.dart
@@ -2,6 +2,7 @@ import 'package:cabin_booking/constants.dart';
 import 'package:cabin_booking/model.dart';
 import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:cabin_booking/utils/dialog.dart';
+import 'package:cabin_booking/utils/time_of_day_extension.dart';
 import 'package:cabin_booking/widgets/standalone/floating_action_button/floating_action_button_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -33,10 +34,12 @@ class BookingFloatingActionButton extends StatelessWidget {
             showNewBookingDialog(
               context: context,
               booking: Booking(
-                date: dayHandler.dateTime.dateOnly,
-                startTime: kTimeTableStartTime,
-                endTime: kTimeTableStartTime.replacing(
-                  hour: (kTimeTableStartTime.hour + 1) % TimeOfDay.hoursPerDay,
+                startDateTime:
+                    dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime),
+                endDateTime: dayHandler.dateTime.addTimeOfDay(
+                  kTimeTableStartTime.increment(
+                    minutes: defaultSlotDuration.inMinutes,
+                  ),
                 ),
                 cabinId: cabinManager.cabins.first.id,
               ),
@@ -54,11 +57,12 @@ class BookingFloatingActionButton extends StatelessWidget {
                 showNewBookingDialog(
                   context: context,
                   booking: RecurringBooking(
-                    date: dayHandler.dateTime.dateOnly,
-                    startTime: kTimeTableStartTime,
-                    endTime: kTimeTableStartTime.replacing(
-                      hour: (kTimeTableStartTime.hour + 1) %
-                          TimeOfDay.hoursPerDay,
+                    startDateTime:
+                        dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime),
+                    endDateTime: dayHandler.dateTime.addTimeOfDay(
+                      kTimeTableStartTime.increment(
+                        minutes: defaultSlotDuration.inMinutes,
+                      ),
                     ),
                     occurrences: 1,
                     cabinId: cabinManager.cabins.first.id,
@@ -77,11 +81,12 @@ class BookingFloatingActionButton extends StatelessWidget {
                 showNewBookingDialog(
                   context: context,
                   booking: Booking(
-                    date: dayHandler.dateTime.dateOnly,
-                    startTime: kTimeTableStartTime,
-                    endTime: kTimeTableStartTime.replacing(
-                      hour: (kTimeTableStartTime.hour + 1) %
-                          TimeOfDay.hoursPerDay,
+                    startDateTime:
+                        dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime),
+                    endDateTime: dayHandler.dateTime.addTimeOfDay(
+                      kTimeTableStartTime.increment(
+                        minutes: defaultSlotDuration.inMinutes,
+                      ),
                     ),
                     isLocked: true,
                     cabinId: cabinManager.cabins.first.id,

--- a/lib/widgets/booking/booking_form.dart
+++ b/lib/widgets/booking/booking_form.dart
@@ -141,7 +141,8 @@ class _BookingFormState extends State<BookingForm> {
                           return appLocalizations.enterStartTime;
                         }
 
-                        _booking.startTime = parsedTimeOfDay;
+                        _booking.startDateTime = _booking.startDateTime!
+                            .addTimeOfDay(parsedTimeOfDay);
 
                         if (_startTime != parsedTimeOfDay) {
                           _startTime = parsedTimeOfDay;
@@ -187,8 +188,11 @@ class _BookingFormState extends State<BookingForm> {
                         });
                       },
                       onSaved: (value) {
-                        _booking.startTime =
+                        final timeOfDay =
                             TimeOfDayExtension.tryParse(value ?? '');
+                        if (timeOfDay == null) return;
+                        _booking.startDateTime =
+                            _booking.startDateTime!.addTimeOfDay(timeOfDay);
                       },
                       decoration: InputDecoration(
                         labelText: appLocalizations.start,
@@ -218,7 +222,8 @@ class _BookingFormState extends State<BookingForm> {
                           return appLocalizations.enterEndTime;
                         }
 
-                        _booking.endTime = parsedTimeOfDay;
+                        _booking.endDateTime =
+                            _booking.endDateTime!.addTimeOfDay(parsedTimeOfDay);
 
                         if (_endTime != parsedTimeOfDay) {
                           _endTime = parsedTimeOfDay;
@@ -264,8 +269,11 @@ class _BookingFormState extends State<BookingForm> {
                         });
                       },
                       onSaved: (value) {
-                        _booking.endTime =
+                        final timeOfDay =
                             TimeOfDayExtension.tryParse(value ?? '');
+                        if (timeOfDay == null) return;
+                        _booking.endDateTime =
+                            _booking.endDateTime!.addTimeOfDay(timeOfDay);
                       },
                       decoration: InputDecoration(
                         labelText: appLocalizations.end,

--- a/lib/widgets/booking/bookings_stack.dart
+++ b/lib/widgets/booking/bookings_stack.dart
@@ -43,9 +43,9 @@ class BookingsStack extends StatelessWidget {
       final isLast = i == bookings.length - 1;
 
       var currentBookingDate =
-          isFirst ? startDateTime : bookings.elementAt(i).endDateTime;
+          isFirst ? startDateTime : bookings.elementAt(i).endDateTime!;
       var nextBookingDateTime =
-          isLast ? endDateTime : bookings.elementAt(i + 1).startDateTime;
+          isLast ? endDateTime : bookings.elementAt(i + 1).startDateTime!;
 
       final duration = nextBookingDateTime.difference(currentBookingDate);
 

--- a/lib/widgets/booking/empty_booking_slot.dart
+++ b/lib/widgets/booking/empty_booking_slot.dart
@@ -1,6 +1,5 @@
 import 'package:cabin_booking/constants.dart';
 import 'package:cabin_booking/model.dart';
-import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:cabin_booking/utils/dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -109,9 +108,8 @@ class _EmptyBookingSlotActionable extends StatelessWidget {
             showNewBookingDialog(
               context: context,
               booking: Booking(
-                date: startDateTime.dateOnly,
-                startTime: TimeOfDay.fromDateTime(startDateTime),
-                endTime: TimeOfDay.fromDateTime(endDateTime),
+                startDateTime: startDateTime,
+                endDateTime: endDateTime,
                 cabinId: cabin.id,
               ),
               cabinManager: cabinManager,


### PR DESCRIPTION
## Motivation

By rewriting inner Booking implementation based on `DateTime`s instead of `TimeOfDay`, we can furtherly store them as UTC to manage local time safely and more reliably (see #90).