### PR TITLE
fix(booking): return `dateOnly` on `date` getter

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -55,8 +55,8 @@ class Booking extends Item {
         _JsonFields.isLocked: isLocked,
       };
 
-  /// Alias for [startDateTime].
-  DateTime? get date => startDateTime;
+  /// Date only part of [startDateTime].
+  DateTime? get date => startDateTime?.dateOnly;
 
   TimeOfDay get startTime => TimeOfDay.fromDateTime(startDateTime!.toLocal());
 


### PR DESCRIPTION
## Context

After #87, the `Booking.date` getter now also included the time part of the `DateTime`, which led to incorrect comparisons between dates that were expected to ignore the time part. See, e.g., `WeekColumns`:

https://github.com/albertms10/cabin_booking/blob/113e42f1c832029c18ed1a0c10bb0394e7d0efcb/lib/widgets/standalone/heat_map_calendar/week_columns.dart#L110-L112