### PR TITLE
fix(map_extension): prevent from mutating this Map in `fillEmptyKeyValues`

### DIFF
--- a/lib/utils/map_extension.dart
+++ b/lib/utils/map_extension.dart
@@ -3,10 +3,12 @@ extension MapExtension<K, V> on Map<K, V> {
     Iterable<K> keys = const [],
     required V Function() ifAbsent,
   }) {
+    final map = Map<K, V>.of(this);
+
     for (final key in keys) {
-      update(key, (value) => value, ifAbsent: ifAbsent);
+      map.update(key, (value) => value, ifAbsent: ifAbsent);
     }
 
-    return this;
+    return map;
   }
 }


### PR DESCRIPTION
Calling `update` on this Map could lead to unexpected issues when using the method in an unmodifiable Map instance (e.g., `const`) or any other unwanted mutations.