### PR TITLE
refactor(color_extension): throw `RangeError` when `samples` is not greater than zero

### DIFF
--- a/lib/utils/color_extension.dart
+++ b/lib/utils/color_extension.dart
@@ -11,7 +11,7 @@ extension ColorExtension on Color {
   /// An optional [minOpacity] value can be provided for the first opacity
   /// value in the Map.
   ///
-  /// Throws an [ArgumentError] if [samples] is not greater than zero.
+  /// Throws a [RangeError] if [samples] is not greater than zero.
   ///
   /// Example:
   /// ```dart
@@ -32,11 +32,7 @@ extension ColorExtension on Color {
     double minOpacity = 0.2,
   }) {
     if (samples <= 0) {
-      throw ArgumentError.value(
-        samples,
-        'samples',
-        'samples must be greater than zero',
-      );
+      throw RangeError.range(samples, 1, null, 'samples');
     }
 
     final colorMap = SplayTreeMap<int, Color>.of({

--- a/test/utils/color_extension_test.dart
+++ b/test/utils/color_extension_test.dart
@@ -19,17 +19,13 @@ void main() {
         );
       });
 
-      test(
-        'should throw an ArgumentError if samples is not '
-        'greater than zero',
-        () {
-          const color = Colors.blue;
-          expect(
-            () => color.opacityThresholds(highestValue: 12, samples: -1),
-            throwsArgumentError,
-          );
-        },
-      );
+      test('should throw a RangeError if samples is not greater than zero', () {
+        const color = Colors.blue;
+        expect(
+          () => color.opacityThresholds(highestValue: 12, samples: -1),
+          throwsRangeError,
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Continues #94