### PR TITLE
fix(recurring_booking): use `startDateTime` instead of `date` only

### DIFF
--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -153,7 +153,7 @@ class RecurringBooking extends Booking {
 
   List<SingleBooking> get bookings {
     final runBookings = <SingleBooking>[];
-    var runDate = date!;
+    var runDate = startDateTime!;
     var movedBooking = asSingleBooking();
 
     var count = 1;

--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -126,7 +126,7 @@ class RecurringBooking extends Booking {
     assert(_recurringEndDate != null, '_recurringEndDate must be non-null.');
 
     var count = 0;
-    var runDate = date!;
+    var runDate = startDateTime!;
 
     while (runDate.isBefore(_recurringEndDate!)) {
       runDate = runDate.add(periodicityDuration);


### PR DESCRIPTION
The issue was introduced in #91

## Context

Using the `Booking.date` getter (date only) instead of `Booking.startDateTime` (which also includes the time part) led to unwanted results when calculating the number of occurrences or getting the bookings in a `RecurringBooking`, which subsequent bookings had the time reset to 0:00 instead of preserving the initial time.