### PR TITLE
refactor: rename `startDateTime` → `startDate` and `date` → `dateOnly`

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -8,15 +8,20 @@ import '../item.dart';
 
 abstract class _JsonFields {
   static const description = 'de';
-  static const startDateTime = 'sd';
-  static const endDateTime = 'ed';
+  static const startDate = 'sd';
+  static const endDate = 'ed';
   static const isLocked = 'il';
 }
 
-abstract class Booking extends Item {
+abstract class Booking extends Item with DateRanger {
   String? description;
-  DateTime? startDateTime;
-  DateTime? endDateTime;
+
+  @override
+  DateTime? startDate;
+
+  @override
+  DateTime? endDate;
+
   bool isLocked;
   String? cabinId;
 
@@ -27,8 +32,8 @@ abstract class Booking extends Item {
   Booking({
     super.id,
     this.description,
-    this.startDateTime,
-    this.endDateTime,
+    this.startDate,
+    this.endDate,
     this.isLocked = false,
     this.cabinId,
     this.recurringBookingId,
@@ -38,11 +43,11 @@ abstract class Booking extends Item {
 
   Booking.from(super.other)
       : description = other[_JsonFields.description] as String?,
-        startDateTime = DateTime.tryParse(
-          other[_JsonFields.startDateTime] as String? ?? '',
+        startDate = DateTime.tryParse(
+          other[_JsonFields.startDate] as String? ?? '',
         ),
-        endDateTime =
-            DateTime.tryParse(other[_JsonFields.endDateTime] as String? ?? ''),
+        endDate =
+            DateTime.tryParse(other[_JsonFields.endDate] as String? ?? ''),
         isLocked = other[_JsonFields.isLocked] as bool,
         super.from();
 
@@ -50,19 +55,17 @@ abstract class Booking extends Item {
   Map<String, dynamic> toJson() => {
         ...super.toJson(),
         _JsonFields.description: description,
-        _JsonFields.startDateTime: startDateTime?.toUtc().toIso8601String(),
-        _JsonFields.endDateTime: endDateTime?.toUtc().toIso8601String(),
+        _JsonFields.startDate: startDate?.toUtc().toIso8601String(),
+        _JsonFields.endDate: endDate?.toUtc().toIso8601String(),
         _JsonFields.isLocked: isLocked,
       };
 
-  /// Date only part of [startDateTime].
-  DateTime? get date => startDateTime?.dateOnly;
+  /// Date only part of [startDate].
+  DateTime? get dateOnly => startDate?.dateOnly;
 
-  TimeOfDay get startTime => TimeOfDay.fromDateTime(startDateTime!.toLocal());
+  TimeOfDay get startTime => TimeOfDay.fromDateTime(startDate!.toLocal());
 
-  TimeOfDay get endTime => TimeOfDay.fromDateTime(endDateTime!.toLocal());
-
-  Duration get duration => endDateTime!.difference(startDateTime!);
+  TimeOfDay get endTime => TimeOfDay.fromDateTime(endDate!.toLocal());
 
   Map<TimeOfDay, Duration> get hoursSpan {
     final timeRanges = <TimeOfDay, Duration>{};
@@ -96,23 +99,22 @@ abstract class Booking extends Item {
       '–${endTime.format24Hour()}';
 
   String get dateTimeRange =>
-      '${DateFormat.yMd().format(startDateTime!)} $timeRange';
+      '${DateFormat.yMd().format(dateOnly!)} $timeRange';
 
-  bool isOn(DateTime dateTime) =>
-      startDateTime?.isSameDateAs(dateTime) ?? false;
+  bool isOn(DateTime dateTime) => dateOnly?.isSameDateAs(dateTime) ?? false;
 
-  bool isBetween(DateRanger dateRange) => dateRange.includes(startDateTime!);
+  bool isBetween(DateRanger dateRange) => dateRange.includes(startDate!);
 
   bool collidesWith(Booking booking) =>
-      startDateTime!.isBefore(booking.endDateTime!) &&
-      endDateTime!.isAfter(booking.startDateTime!);
+      startDate!.isBefore(booking.endDate!) &&
+      endDate!.isAfter(booking.startDate!);
 
   @override
   Booking copyWith({
     String? id,
     String? description,
-    DateTime? startDateTime,
-    DateTime? endDateTime,
+    DateTime? startDate,
+    DateTime? endDate,
     bool? isLocked,
     String? cabinId,
   });
@@ -120,8 +122,8 @@ abstract class Booking extends Item {
   @override
   void replaceWith(covariant Booking item) {
     description = item.description;
-    startDateTime = item.startDateTime;
-    endDateTime = item.endDateTime;
+    startDate = item.startDate;
+    endDate = item.endDate;
     isLocked = item.isLocked;
 
     super.replaceWith(item);
@@ -133,5 +135,5 @@ abstract class Booking extends Item {
 
   @override
   int compareTo(covariant Booking other) =>
-      startDateTime!.compareTo(other.startDateTime!);
+      startDate!.compareTo(other.startDate!);
 }

--- a/lib/src/model/booking/booking_manager.dart
+++ b/lib/src/model/booking/booking_manager.dart
@@ -94,9 +94,9 @@ class BookingManager with ChangeNotifier {
       });
 
   bool bookingsCollideWith(Booking booking) {
-    if (booking.date == null) return false;
+    if (booking.dateOnly == null) return false;
 
-    return allBookingsOn(booking.date!)
+    return allBookingsOn(booking.dateOnly!)
             .where(
               (comparingBooking) =>
                   (comparingBooking.recurringBookingId == null ||
@@ -178,11 +178,13 @@ class BookingManager with ChangeNotifier {
 
     for (final booking in bookingsList) {
       final shouldAddDate = dates.firstWhereOrNull(
-            (date) => booking.date != null && date.isSameDateAs(booking.date!),
+            (date) =>
+                booking.dateOnly != null &&
+                date.isSameDateAs(booking.dateOnly!),
           ) !=
           null;
 
-      if (!shouldAddDate) dates.add(booking.date!);
+      if (!shouldAddDate) dates.add(booking.dateOnly!);
     }
 
     return dates;
@@ -193,7 +195,7 @@ class BookingManager with ChangeNotifier {
 
     for (final booking in allBookings) {
       bookingsPerDay.update(
-        booking.date!,
+        booking.dateOnly!,
         (count) => count + 1,
         ifAbsent: () => 1,
       );
@@ -206,10 +208,10 @@ class BookingManager with ChangeNotifier {
     final bookingsPerDay = SplayTreeMap<DateTime, Duration>();
 
     for (final booking in allBookings) {
-      if (dateRange != null && !dateRange.includes(booking.date!)) continue;
+      if (dateRange != null && !dateRange.includes(booking.dateOnly!)) continue;
 
       bookingsPerDay.update(
-        booking.date!.firstDayOfWeek,
+        booking.dateOnly!.firstDayOfWeek,
         (duration) => duration + booking.duration,
         ifAbsent: () => booking.duration,
       );

--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -20,8 +20,8 @@ class RecurringBooking extends Booking {
   RecurringBooking({
     super.id,
     super.description,
-    super.startDateTime,
-    super.endDateTime,
+    super.startDate,
+    super.endDate,
     super.isLocked,
     super.cabinId,
     this.periodicity = Periodicity.weekly,
@@ -74,8 +74,8 @@ class RecurringBooking extends Booking {
     return RecurringBooking(
       id: booking.id,
       description: booking.description,
-      startDateTime: booking.startDateTime,
-      endDateTime: booking.endDateTime,
+      startDate: booking.startDate,
+      endDate: booking.endDate,
       isLocked: booking.isLocked,
       cabinId: booking.cabinId,
       periodicity: periodicity,
@@ -112,7 +112,7 @@ class RecurringBooking extends Booking {
 
     assert(_occurrences != null, '_occurrences must be non-null.');
 
-    return date!.add(periodicityDuration * _occurrences!);
+    return dateOnly!.add(periodicityDuration * _occurrences!);
   }
 
   set recurringEndDate(DateTime date) {
@@ -126,7 +126,7 @@ class RecurringBooking extends Booking {
     assert(_recurringEndDate != null, '_recurringEndDate must be non-null.');
 
     var count = 0;
-    var runDate = startDateTime!;
+    var runDate = startDate!;
 
     while (runDate.isBefore(_recurringEndDate!)) {
       runDate = runDate.add(periodicityDuration);
@@ -144,8 +144,8 @@ class RecurringBooking extends Booking {
   SingleBooking asSingleBooking({bool linked = true}) => SingleBooking(
         id: linked ? '$id-0' : (recurringBookingId ?? id),
         description: description,
-        startDateTime: startDateTime,
-        endDateTime: endDateTime,
+        startDate: startDate,
+        endDate: endDate,
         isLocked: isLocked,
         cabinId: cabinId,
         recurringBookingId: linked ? id : null,
@@ -153,7 +153,7 @@ class RecurringBooking extends Booking {
 
   List<SingleBooking> get bookings {
     final runBookings = <SingleBooking>[];
-    var runDate = startDateTime!;
+    var runDate = startDate!;
     var movedBooking = asSingleBooking();
 
     var count = 1;
@@ -171,8 +171,8 @@ class RecurringBooking extends Booking {
 
       if (runDate.isBefore(recurringEndDate)) {
         movedBooking = movedBooking.copyWith(
-          startDateTime: runDate,
-          endDateTime: runDate.add(duration),
+          startDate: runDate,
+          endDate: runDate.add(duration),
         );
         count++;
       }
@@ -191,8 +191,8 @@ class RecurringBooking extends Booking {
   RecurringBooking copyWith({
     String? id,
     String? description,
-    DateTime? startDateTime,
-    DateTime? endDateTime,
+    DateTime? startDate,
+    DateTime? endDate,
     bool? isLocked,
     String? cabinId,
     Periodicity? periodicity,
@@ -203,8 +203,8 @@ class RecurringBooking extends Booking {
       RecurringBooking(
         id: id ?? this.id,
         description: description ?? this.description,
-        startDateTime: startDateTime ?? this.startDateTime,
-        endDateTime: endDateTime ?? this.endDateTime,
+        startDate: startDate ?? startDate,
+        endDate: endDate ?? endDate,
         isLocked: isLocked ?? this.isLocked,
         cabinId: cabinId ?? this.cabinId,
         periodicity: periodicity ?? this.periodicity,

--- a/lib/src/model/booking/single_booking.dart
+++ b/lib/src/model/booking/single_booking.dart
@@ -4,8 +4,8 @@ class SingleBooking extends Booking {
   SingleBooking({
     super.id,
     super.description,
-    super.startDateTime,
-    super.endDateTime,
+    super.startDate,
+    super.endDate,
     super.isLocked = false,
     super.cabinId,
     super.recurringBookingId,
@@ -19,8 +19,8 @@ class SingleBooking extends Booking {
       : super(
           id: booking.id,
           description: booking.description,
-          startDateTime: booking.startDateTime,
-          endDateTime: booking.endDateTime,
+          startDate: booking.startDate,
+          endDate: booking.endDate,
           isLocked: booking.isLocked,
           cabinId: booking.cabinId,
         );
@@ -29,16 +29,16 @@ class SingleBooking extends Booking {
   SingleBooking copyWith({
     String? id,
     String? description,
-    DateTime? startDateTime,
-    DateTime? endDateTime,
+    DateTime? startDate,
+    DateTime? endDate,
     bool? isLocked,
     String? cabinId,
   }) =>
       SingleBooking(
         id: id ?? super.id,
         description: description ?? this.description,
-        startDateTime: startDateTime ?? this.startDateTime,
-        endDateTime: endDateTime ?? this.endDateTime,
+        startDate: startDate ?? startDate,
+        endDate: endDate ?? endDate,
         isLocked: isLocked ?? this.isLocked,
         cabinId: cabinId ?? this.cabinId,
       );

--- a/lib/src/model/booking/tokenized_booking.dart
+++ b/lib/src/model/booking/tokenized_booking.dart
@@ -148,8 +148,8 @@ class TokenizedBooking {
     }
 
     return SingleBooking(
-      startDateTime: now.addTimeOfDay(startTime),
-      endDateTime: now.addTimeOfDay(endTime),
+      startDate: now.addTimeOfDay(startTime),
+      endDate: now.addTimeOfDay(endTime),
     );
   }
 

--- a/lib/src/model/cabin/cabin_manager.dart
+++ b/lib/src/model/cabin/cabin_manager.dart
@@ -357,7 +357,7 @@ class CabinManager extends WritableManager<Set<Cabin>> with ChangeNotifier {
             ...cabin.searchBookings(query, limit: perCabinLimit),
         ],
         // Descending.
-        (a, b) => b.startDateTime!.compareTo(a.startDateTime!),
+        (a, b) => b.startDate!.compareTo(a.startDate!),
       );
 
   Set<Cabin> get _defaultCabins => SplayTreeSet();

--- a/lib/src/model/date/date_range.dart
+++ b/lib/src/model/date/date_range.dart
@@ -37,11 +37,11 @@ class DateRange with DateRanger {
   /// assert(dateRange.endDate == DateTime(2022, 12, 5));
   /// ```
   factory DateRange.from(DateTime dateTime) {
-    final startDate = dateTime.dateOnly;
+    final startDateOnly = dateTime.dateOnly;
 
     return DateRange(
-      startDate: startDate,
-      endDate: startDate.add(const Duration(days: 1)),
+      startDate: startDateOnly,
+      endDate: startDateOnly.add(const Duration(days: 1)),
     );
   }
 

--- a/lib/src/model/item.dart
+++ b/lib/src/model/item.dart
@@ -5,8 +5,8 @@ import 'serializable.dart';
 
 abstract class _JsonFields {
   static const id = 'id';
-  static const creationDateTime = 'cdt';
-  static const modificationDateTime = 'mdt';
+  static const creationDateTime = 'cd';
+  static const modificationDateTime = 'md';
   static const modificationCount = 'mc';
 }
 

--- a/lib/widgets/booking/booking_card.dart
+++ b/lib/widgets/booking/booking_card.dart
@@ -24,7 +24,7 @@ class BookingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isBeforeNow = booking.endDateTime!.isBefore(DateTime.now());
+    final isBeforeNow = booking.endDate!.isBefore(DateTime.now());
 
     return TimerBuilder.periodic(
       const Duration(minutes: 1),

--- a/lib/widgets/booking/booking_floating_action_button.dart
+++ b/lib/widgets/booking/booking_floating_action_button.dart
@@ -32,9 +32,9 @@ class BookingFloatingActionButton extends StatelessWidget {
                 showNewBookingDialog(
                   context: context,
                   booking: RecurringBooking(
-                    startDateTime:
+                    startDate:
                         dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime),
-                    endDateTime: dayHandler.dateTime.addTimeOfDay(
+                    endDate: dayHandler.dateTime.addTimeOfDay(
                       kTimeTableStartTime.increment(
                         minutes: defaultSlotDuration.inMinutes,
                       ),
@@ -56,9 +56,9 @@ class BookingFloatingActionButton extends StatelessWidget {
                 showNewBookingDialog(
                   context: context,
                   booking: SingleBooking(
-                    startDateTime:
+                    startDate:
                         dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime),
-                    endDateTime: dayHandler.dateTime.addTimeOfDay(
+                    endDate: dayHandler.dateTime.addTimeOfDay(
                       kTimeTableStartTime.increment(
                         minutes: defaultSlotDuration.inMinutes,
                       ),
@@ -82,9 +82,9 @@ class BookingFloatingActionButton extends StatelessWidget {
             showNewBookingDialog(
               context: context,
               booking: SingleBooking(
-                startDateTime:
+                startDate:
                     dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime),
-                endDateTime: dayHandler.dateTime.addTimeOfDay(
+                endDate: dayHandler.dateTime.addTimeOfDay(
                   kTimeTableStartTime.increment(
                     minutes: defaultSlotDuration.inMinutes,
                   ),

--- a/lib/widgets/booking/booking_form.dart
+++ b/lib/widgets/booking/booking_form.dart
@@ -155,8 +155,8 @@ class _BookingFormState extends State<BookingForm> {
                         final timeOfDay =
                             TimeOfDayExtension.tryParse(value ?? '');
                         if (timeOfDay == null) return;
-                        _booking.startDateTime =
-                            _booking.startDateTime!.addTimeOfDay(timeOfDay);
+                        _booking.startDate =
+                            _booking.startDate!.addTimeOfDay(timeOfDay);
                       },
                       validator: (value) {
                         if (value == null || value.isEmpty) {
@@ -170,21 +170,21 @@ class _BookingFormState extends State<BookingForm> {
                           return appLocalizations.enterStartTime;
                         }
 
-                        _booking.startDateTime = _booking.startDateTime!
-                            .addTimeOfDay(parsedTimeOfDay);
+                        _booking.startDate =
+                            _booking.startDate!.addTimeOfDay(parsedTimeOfDay);
 
                         if (_startTime != parsedTimeOfDay) {
                           _startTime = parsedTimeOfDay;
                         }
 
-                        final parsedDateTime =
-                            widget.booking.date!.addTimeOfDay(parsedTimeOfDay);
+                        final parsedDateTime = widget.booking.dateOnly!
+                            .addTimeOfDay(parsedTimeOfDay);
 
                         if (parsedDateTime.isAfter(
-                              widget.booking.date!.addTimeOfDay(_endTime),
+                              widget.booking.dateOnly!.addTimeOfDay(_endTime),
                             ) ||
                             parsedDateTime.isBefore(
-                              widget.booking.date!
+                              widget.booking.dateOnly!
                                   .addTimeOfDay(kTimeTableStartTime),
                             )) {
                           return appLocalizations.enterValidRange;
@@ -234,8 +234,8 @@ class _BookingFormState extends State<BookingForm> {
                         final timeOfDay =
                             TimeOfDayExtension.tryParse(value ?? '');
                         if (timeOfDay == null) return;
-                        _booking.endDateTime =
-                            _booking.endDateTime!.addTimeOfDay(timeOfDay);
+                        _booking.endDate =
+                            _booking.endDate!.addTimeOfDay(timeOfDay);
                       },
                       validator: (value) {
                         if (value == null || value.isEmpty) {
@@ -249,21 +249,21 @@ class _BookingFormState extends State<BookingForm> {
                           return appLocalizations.enterEndTime;
                         }
 
-                        _booking.endDateTime =
-                            _booking.endDateTime!.addTimeOfDay(parsedTimeOfDay);
+                        _booking.endDate =
+                            _booking.endDate!.addTimeOfDay(parsedTimeOfDay);
 
                         if (_endTime != parsedTimeOfDay) {
                           _endTime = parsedTimeOfDay;
                         }
 
-                        final parsedDateTime =
-                            widget.booking.date!.addTimeOfDay(parsedTimeOfDay);
+                        final parsedDateTime = widget.booking.dateOnly!
+                            .addTimeOfDay(parsedTimeOfDay);
 
                         if (parsedDateTime.isBefore(
-                              widget.booking.date!.addTimeOfDay(_startTime),
+                              widget.booking.dateOnly!.addTimeOfDay(_startTime),
                             ) ||
                             parsedDateTime.isAfter(
-                              widget.booking.date!
+                              widget.booking.dateOnly!
                                   .addTimeOfDay(kTimeTableEndTime),
                             )) {
                           return appLocalizations.enterValidRange;

--- a/lib/widgets/booking/booking_preview_panel.dart
+++ b/lib/widgets/booking/booking_preview_panel.dart
@@ -61,7 +61,7 @@ class _BookingPreviewPanelHeadline extends StatelessWidget {
       headline: booking.description!,
       description: Row(
         children: [
-          Text(DateFormat.MMMMEEEEd().format(booking.date!)),
+          Text(DateFormat.MMMMEEEEd().format(booking.dateOnly!)),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
             child: Text(

--- a/lib/widgets/booking/bookings_stack.dart
+++ b/lib/widgets/booking/bookings_stack.dart
@@ -33,8 +33,8 @@ class BookingsStack extends StatelessWidget {
 
     final dayHandler = Provider.of<DayHandler>(context);
 
-    final startDateTime = dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime);
-    final endDateTime = dayHandler.dateTime.addTimeOfDay(kTimeTableEndTime);
+    final startDate = dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime);
+    final endDate = dayHandler.dateTime.addTimeOfDay(kTimeTableEndTime);
 
     var slotCount = 0;
 
@@ -43,9 +43,9 @@ class BookingsStack extends StatelessWidget {
       final isLast = i == bookings.length - 1;
 
       var currentBookingDate =
-          isFirst ? startDateTime : bookings.elementAt(i).endDateTime!;
+          isFirst ? startDate : bookings.elementAt(i).endDate!;
       var nextBookingDateTime =
-          isLast ? endDateTime : bookings.elementAt(i + 1).startDateTime!;
+          isLast ? endDate : bookings.elementAt(i + 1).startDate!;
 
       final duration = nextBookingDateTime.difference(currentBookingDate);
 
@@ -84,8 +84,8 @@ class BookingsStack extends StatelessWidget {
             EmptyBookingSlot(
               key: _emptyBookingSlotKey(currentBookingDate, slotCount++),
               cabin: cabin,
-              startDateTime: currentBookingDate,
-              endDateTime: nextBookingDateTime,
+              startDate: currentBookingDate,
+              endDate: nextBookingDateTime,
             ),
           );
 
@@ -100,8 +100,8 @@ class BookingsStack extends StatelessWidget {
           EmptyBookingSlot(
             key: _emptyBookingSlotKey(currentBookingDate, slotCount++),
             cabin: cabin,
-            startDateTime: currentBookingDate,
-            endDateTime: nextBookingDateTime,
+            startDate: currentBookingDate,
+            endDate: nextBookingDateTime,
           ),
         );
 

--- a/lib/widgets/booking/empty_booking_slot.dart
+++ b/lib/widgets/booking/empty_booking_slot.dart
@@ -7,14 +7,14 @@ import 'package:timer_builder/timer_builder.dart';
 
 class EmptyBookingSlot extends StatelessWidget {
   final Cabin cabin;
-  final DateTime startDateTime;
-  final DateTime endDateTime;
+  final DateTime startDate;
+  final DateTime endDate;
 
   const EmptyBookingSlot({
     super.key,
     required this.cabin,
-    required this.startDateTime,
-    required this.endDateTime,
+    required this.startDate,
+    required this.endDate,
   });
 
   @override
@@ -24,13 +24,13 @@ class EmptyBookingSlot extends StatelessWidget {
       builder: (context) {
         final now = DateTime.now();
 
-        final fullDuration = endDateTime.difference(startDateTime);
+        final fullDuration = endDate.difference(startDate);
 
-        final startToNowDuration = now.difference(startDateTime);
-        final startsBeforeNow = now.compareTo(startDateTime) > 0;
+        final startToNowDuration = now.difference(startDate);
+        final startsBeforeNow = now.compareTo(startDate) > 0;
 
-        final endToNowDuration = endDateTime.difference(now);
-        final endsAfterNow = endDateTime.compareTo(now) > 0;
+        final endToNowDuration = endDate.difference(now);
+        final endsAfterNow = endDate.compareTo(now) > 0;
 
         final duration =
             startsBeforeNow && endsAfterNow ? endToNowDuration : fullDuration;
@@ -56,12 +56,12 @@ class EmptyBookingSlot extends StatelessWidget {
                   width: double.infinity,
                   height: value,
                   child: duration.compareTo(kMinSlotDuration) < 0 ||
-                          endDateTime.compareTo(now) < 0
+                          endDate.compareTo(now) < 0
                       ? null
                       : _EmptyBookingSlotActionable(
                           cabin: cabin,
-                          startDateTime: startsBeforeNow ? now : startDateTime,
-                          endDateTime: endDateTime,
+                          startDate: startsBeforeNow ? now : startDate,
+                          endDate: endDate,
                           preciseDuration: preciseDuration,
                         ),
                 );
@@ -76,15 +76,15 @@ class EmptyBookingSlot extends StatelessWidget {
 
 class _EmptyBookingSlotActionable extends StatelessWidget {
   final Cabin cabin;
-  final DateTime startDateTime;
-  final DateTime endDateTime;
+  final DateTime startDate;
+  final DateTime endDate;
   final int? preciseDuration;
 
   const _EmptyBookingSlotActionable({
     super.key,
     required this.cabin,
-    required this.startDateTime,
-    required this.endDateTime,
+    required this.startDate,
+    required this.endDate,
     this.preciseDuration,
   });
 
@@ -92,8 +92,7 @@ class _EmptyBookingSlotActionable extends StatelessWidget {
   Widget build(BuildContext context) {
     final cabinManager = Provider.of<CabinManager>(context, listen: false);
 
-    final duration =
-        preciseDuration ?? endDateTime.difference(startDateTime).inMinutes;
+    final duration = preciseDuration ?? endDate.difference(startDate).inMinutes;
 
     return Container(
       decoration: const BoxDecoration(
@@ -107,8 +106,8 @@ class _EmptyBookingSlotActionable extends StatelessWidget {
             showNewBookingDialog(
               context: context,
               booking: SingleBooking(
-                startDateTime: startDateTime,
-                endDateTime: endDateTime,
+                startDate: startDate,
+                endDate: endDate,
                 cabinId: cabin.id,
               ),
               cabinManager: cabinManager,

--- a/lib/widgets/jump_bar/booking_search_result.dart
+++ b/lib/widgets/jump_bar/booking_search_result.dart
@@ -37,10 +37,10 @@ class BookingSearchResult extends StatelessWidget {
             ),
             const SizedBox(width: 12),
             SearchResultLabel<DateRange>(
-              label: booking.date != null
+              label: booking.dateOnly != null
                   ? DateRange(
-                      startDate: booking.startDateTime,
-                      endDate: booking.endDateTime,
+                      startDate: booking.startDate,
+                      endDate: booking.endDate,
                     )
                   : null,
               formatter: (dateRange) {

--- a/lib/widgets/jump_bar/jump_bar_results.dart
+++ b/lib/widgets/jump_bar/jump_bar_results.dart
@@ -51,7 +51,7 @@ class JumpBarResults extends StatelessWidget {
             JumpBarItem(
               icon: Icons.event,
               onTap: () {
-                dayHandler.dateTime = booking.startDateTime!;
+                dayHandler.dateTime = booking.startDate!;
                 Navigator.of(context).pop();
                 HomePage.of(homePageContext)
                     ?.setNavigationPage(AppPage.bookings);

--- a/lib/widgets/layout/current_time_indicator.dart
+++ b/lib/widgets/layout/current_time_indicator.dart
@@ -18,14 +18,13 @@ class CurrentTimeIndicator extends StatelessWidget {
       builder: (context) {
         final dayHandler = Provider.of<DayHandler>(context);
 
-        final viewStartDateTime =
+        final viewStartDate =
             dayHandler.dateTime.addTimeOfDay(kTimeTableStartTime);
-        final viewEndDateTime =
-            dayHandler.dateTime.addTimeOfDay(kTimeTableEndTime);
+        final viewEndDate = dayHandler.dateTime.addTimeOfDay(kTimeTableEndTime);
 
         final now = DateTime.now();
-        final durationFromStart = now.difference(viewStartDateTime);
-        final durationFromEnd = now.difference(viewEndDateTime);
+        final durationFromStart = now.difference(viewStartDate);
+        final durationFromEnd = now.difference(viewEndDate);
 
         if (durationFromStart <= Duration.zero ||
             durationFromEnd >= const Duration(minutes: 15)) {

--- a/test/model/cabin/cabin_test.dart
+++ b/test/model/cabin/cabin_test.dart
@@ -7,8 +7,8 @@ void main() {
       test('should create a new Cabin from a JSON object', () {
         const rawCabin = {
           'id': 'cabin-id',
-          'cdt': '1969-07-20T20:18:04.000Z',
-          'mdt': '1969-07-20T20:18:04.000Z',
+          'cd': '1969-07-20T20:18:04.000Z',
+          'md': '1969-07-20T20:18:04.000Z',
           'mc': 1,
           'n': 1,
           'e': {
@@ -47,8 +47,8 @@ void main() {
         () {
           final rawCabin = {
             'id': 'cabin-id',
-            'cdt': '1969-07-20T20:18:04.000Z',
-            'mdt': '1969-07-20T20:18:04.000Z',
+            'cd': '1969-07-20T20:18:04.000Z',
+            'md': '1969-07-20T20:18:04.000Z',
             'mc': 1,
             'n': 1,
             'e': {

--- a/test/model/main.dart
+++ b/test/model/main.dart
@@ -8,8 +8,8 @@ import 'date/date_ranger_test.dart' as date_ranger_test;
 void main() {
   cabin_elements_test.main();
   cabin_test.main();
-  tokenized_cabin_test.main();
   piano_test.main();
+  tokenized_cabin_test.main();
   date_range_test.main();
   date_ranger_test.main();
 }


### PR DESCRIPTION
This PR aims to improve naming predictability, being explicit on the difference between _date_ and _date only_ members:

- `*DateTime` → `*Date`
- `date` → `dateOnly`

Additionally, makes the `Booking` class implement the `DateRanger` mixin.