### PR TITLE
fix(date_time_extension): keep UTC information

### DIFF
--- a/lib/src/model/school_year/school_year_manager.dart
+++ b/lib/src/model/school_year/school_year_manager.dart
@@ -134,20 +134,20 @@ class SchoolYearManager extends WritableManager<Set<SchoolYear>>
 
   Set<SchoolYear> get _defaultSchoolYears => SplayTreeSet.of({
         SchoolYear(
-          startDate: DateTime(2018, DateTime.september, 3),
-          endDate: DateTime(2019, DateTime.july, 26),
+          startDate: DateTime.utc(2018, DateTime.september, 3),
+          endDate: DateTime.utc(2019, DateTime.july, 26),
         ),
         SchoolYear(
-          startDate: DateTime(2019, DateTime.september, 2),
-          endDate: DateTime(2020, DateTime.july, 25),
+          startDate: DateTime.utc(2019, DateTime.september, 2),
+          endDate: DateTime.utc(2020, DateTime.july, 25),
         ),
         SchoolYear(
-          startDate: DateTime(2020, DateTime.september),
-          endDate: DateTime(2021, DateTime.july, 24),
+          startDate: DateTime.utc(2020, DateTime.september),
+          endDate: DateTime.utc(2021, DateTime.july, 24),
         ),
         SchoolYear(
-          startDate: DateTime(2021, DateTime.august, 31),
-          endDate: DateTime(2022, DateTime.july, 23),
+          startDate: DateTime.utc(2021, DateTime.august, 31),
+          endDate: DateTime.utc(2022, DateTime.july, 23),
         ),
       });
 

--- a/lib/utils/date_time_extension.dart
+++ b/lib/utils/date_time_extension.dart
@@ -4,14 +4,16 @@ import 'package:intl/intl.dart';
 
 /// DateTime extension.
 extension DateTimeExtension on DateTime {
-  /// Returns a new [DateTime] with the date part only (ignoring the time part).
+  /// Returns a new [DateTime] with the date part only (ignoring the time part)
+  /// while keeping UTC information.
   ///
   /// Example:
   /// ```dart
   /// final dateTime = DateTime(2021, 9, 7, 21, 30, 10);
   /// assert(dateTime.dateOnly == DateTime(2021, 9, 7));
   /// ```
-  DateTime get dateOnly => DateTime(year, month, day);
+  DateTime get dateOnly =>
+      (isUtc ? DateTime.utc : DateTime.new)(year, month, day);
 
   /// Returns a new [DateTime] replacing the time part with [timeOfDay].
   ///
@@ -25,8 +27,9 @@ extension DateTimeExtension on DateTime {
   /// ```
   DateTime addTimeOfDay([TimeOfDay? timeOfDay]) {
     timeOfDay ??= TimeOfDay.now();
+    final newDateTime = isUtc ? DateTime.utc : DateTime.new;
 
-    return DateTime(year, month, day, timeOfDay.hour, timeOfDay.minute);
+    return newDateTime(year, month, day, timeOfDay.hour, timeOfDay.minute);
   }
 
   /// Whether this [DateTime] occurs on the same date as [other].

--- a/test/utils/date_time_extension_test.dart
+++ b/test/utils/date_time_extension_test.dart
@@ -5,9 +5,20 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('DateTimeExtension', () {
     group('.dateOnly', () {
-      test('should return only the date information of this DateTime', () {
-        expect(DateTime(2021, 9, 7, 21, 30, 10).dateOnly, DateTime(2021, 9, 7));
-      });
+      test(
+        'should return only the date information of this DateTime, keeping '
+        'UTC information',
+        () {
+          expect(
+            DateTime(2021, 9, 7, 21, 30, 10).dateOnly,
+            DateTime(2021, 9, 7),
+          );
+          expect(
+            DateTime.utc(2021, 9, 7, 21, 30, 10).dateOnly,
+            DateTime.utc(2021, 9, 7),
+          );
+        },
+      );
     });
 
     group('.addTimeOfDay()', () {


### PR DESCRIPTION
This PR aims to respect the original UTC information on `dateOnly` and `addTimeOfDay` extension methods.