### PR TITLE
refactor(holiday)!: extend `DateRange` instead of `DateRangeItem`

### DIFF
--- a/lib/src/model/date/date_range.dart
+++ b/lib/src/model/date/date_range.dart
@@ -2,11 +2,17 @@ import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../serializable.dart';
 import 'date_ranger.dart';
+
+abstract class _JsonFields {
+  static const startDate = 'sd';
+  static const endDate = 'ed';
+}
 
 /// A representation of the range between two [DateTime] objects.
 @immutable
-class DateRange with DateRanger {
+class DateRange with DateRanger implements Comparable<DateRange>, Serializable {
   @override
   final DateTime? startDate;
 
@@ -19,6 +25,16 @@ class DateRange with DateRanger {
   /// A [DateRange] with no start nor end dates, representing a range that
   /// includes all possible dates.
   static const infinite = DateRange();
+
+  DateRange.fromJson(Map<String, dynamic> other)
+      : startDate = DateTime.tryParse(other[_JsonFields.startDate] as String),
+        endDate = DateTime.tryParse(other[_JsonFields.endDate] as String);
+
+  @override
+  Map<String, dynamic> toJson() => {
+        _JsonFields.startDate: startDate?.toUtc().toIso8601String(),
+        _JsonFields.endDate: endDate?.toUtc().toIso8601String(),
+      };
 
   /// Creates a copy of this [DateRange] but with the given fields replaced
   /// with the new values.
@@ -60,4 +76,8 @@ class DateRange with DateRanger {
 
   @override
   int get hashCode => Object.hash(startDate, endDate);
+
+  @override
+  int compareTo(covariant DateRange other) =>
+      startDate!.compareTo(other.startDate!);
 }

--- a/lib/src/model/date/date_ranger.dart
+++ b/lib/src/model/date/date_ranger.dart
@@ -11,7 +11,7 @@ mixin DateRanger {
 
   /// The start [DateTime] of this [DateRanger].
   ///
-  /// If null, represents a [DateRanger] including all dates starting from
+  /// If null, it represents a [DateRanger] including all dates starting from
   /// [startDate].
   DateTime? get endDate;
 

--- a/lib/src/model/date/holiday.dart
+++ b/lib/src/model/date/holiday.dart
@@ -16,9 +16,9 @@ class Holiday extends DateRange {
     required this.kind,
   });
 
-  Holiday.from(super.other)
+  Holiday.fromJson(super.other)
       : kind = HolidayKind.values[other[_JsonFields.kind] as int],
-        super.from();
+        super.fromJson();
 
   @override
   Map<String, dynamic> toJson() => {

--- a/lib/src/model/date/holiday.dart
+++ b/lib/src/model/date/holiday.dart
@@ -1,17 +1,19 @@
-import 'date_range_item.dart';
+import 'package:flutter/foundation.dart' show immutable;
+
+import 'date_range.dart';
 
 abstract class _JsonFields {
   static const kind = 'k';
 }
 
-class Holiday extends DateRangeItem {
+@immutable
+class Holiday extends DateRange {
   final HolidayKind kind;
 
-  Holiday({
-    super.id,
+  const Holiday({
     super.startDate,
     super.endDate,
-    this.kind = HolidayKind.festivity,
+    required this.kind,
   });
 
   Holiday.from(super.other)

--- a/lib/src/model/school_year/school_year.dart
+++ b/lib/src/model/school_year/school_year.dart
@@ -25,7 +25,7 @@ class SchoolYear extends DateRangeItem {
       : holidays = SplayTreeSet.of(
           (other[_JsonFields.holidays] as List<dynamic>)
               .cast<Map<String, dynamic>>()
-              .map<Holiday>(Holiday.from),
+              .map<Holiday>(Holiday.fromJson),
         ),
         super.from();
 

--- a/test/model/date/holiday_test.dart
+++ b/test/model/date/holiday_test.dart
@@ -6,32 +6,25 @@ void main() {
     group('.from()', () {
       test('should create a new Holiday from a JSON object', () {
         const rawHoliday = {
-          'id': 'holiday-id',
-          'cd': '1969-07-20T20:18:04.000Z',
-          'md': '1969-07-20T20:18:04.000Z',
-          'mc': 1,
           'sd': '2022-09-11T00:00:00.000Z',
           'ed': '2022-09-12T00:00:00.000Z',
           'k': 0,
         };
         final holiday = Holiday.from(rawHoliday);
-        final h = Holiday(
-          id: 'holiday-id',
-          startDate: DateTime.utc(2022, 9, 11),
-          endDate: DateTime.utc(2022, 9, 12),
+        expect(
+          holiday,
+          Holiday(
+            startDate: DateTime.utc(2022, 9, 11),
+            endDate: DateTime.utc(2022, 9, 12),
+            kind: HolidayKind.festivity,
+          ),
         );
-
-        expect(holiday, h);
       });
     });
 
     group('.toJson()', () {
       test('should return a JSON object representation of this Holiday', () {
         const rawHoliday = {
-          'id': 'holiday-id',
-          'cd': '1969-07-20T20:18:04.000Z',
-          'md': '1969-07-20T20:18:04.000Z',
-          'mc': 1,
           'sd': '2022-10-31T00:00:00.000Z',
           'ed': '2022-11-01T00:00:00.000Z',
           'k': 1,

--- a/test/model/date/holiday_test.dart
+++ b/test/model/date/holiday_test.dart
@@ -3,14 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Holiday', () {
-    group('.from()', () {
+    group('.fromJson()', () {
       test('should create a new Holiday from a JSON object', () {
         const rawHoliday = {
           'sd': '2022-09-11T00:00:00.000Z',
           'ed': '2022-09-12T00:00:00.000Z',
           'k': 0,
         };
-        final holiday = Holiday.from(rawHoliday);
+        final holiday = Holiday.fromJson(rawHoliday);
         expect(
           holiday,
           Holiday(
@@ -29,7 +29,7 @@ void main() {
           'ed': '2022-11-01T00:00:00.000Z',
           'k': 1,
         };
-        expect(Holiday.from(rawHoliday).toJson(), rawHoliday);
+        expect(Holiday.fromJson(rawHoliday).toJson(), rawHoliday);
       });
     });
   });


### PR DESCRIPTION
**Breaking change:** The `Holiday` class will no longer be considered a descendant of `Item`, and will instead be inheriting the standalone `DateRange` class, meaning it will lose all `Item` specific properties—such as a unique ID and creation and modification information.

This PR also makes `DateRange` implement `Comparable` and `Serializable` interfaces.