### PR TITLE
test(iterable_extension): use `const`

### DIFF
--- a/test/utils/iterable_extension_test.dart
+++ b/test/utils/iterable_extension_test.dart
@@ -17,15 +17,18 @@ void main() {
       test('should throw an ArgumentError', () {
         expect(() => const [true].compactConsecutive(), throwsArgumentError);
         expect(() => [() {}].compactConsecutive(), throwsArgumentError);
-        expect(() => [<bool>[]].compactConsecutive(), throwsArgumentError);
         expect(
-          () => [
+          () => const [<bool>[]].compactConsecutive(),
+          throwsArgumentError,
+        );
+        expect(
+          () => const [
             {''},
           ].compactConsecutive(),
           throwsArgumentError,
         );
         expect(
-          () => [
+          () => const [
             {'': ''},
           ].compactConsecutive(),
           throwsArgumentError,


### PR DESCRIPTION
This PR aims to initialize lists in tests with `const` where possible.