### PR TITLE
fix(recurring_booking): use correct `copyWith` default values

### DIFF
--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -203,8 +203,8 @@ class RecurringBooking extends Booking {
   }) =>
       RecurringBooking(
         id: id ?? this.id,
-        startDate: startDate ?? startDate,
-        endDate: endDate ?? endDate,
+        startDate: startDate ?? this.startDate,
+        endDate: endDate ?? this.endDate,
         description: description ?? this.description,
         isLocked: isLocked ?? this.isLocked,
         cabinId: cabinId ?? this.cabinId,


### PR DESCRIPTION
Addresses an issue introduced in #131 