### PR TITLE
refactor(single_booking): replace `recurringBookingId` with referenced object

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -3,6 +3,7 @@ import 'package:cabin_booking/utils/time_of_day_extension.dart';
 import 'package:intl/intl.dart';
 
 import '../date/date_range_item.dart';
+import 'recurring_booking.dart';
 
 abstract class _JsonFields {
   static const description = 'de';
@@ -20,16 +21,13 @@ abstract class Booking extends DateRangeItem {
   /// The ID of the booked Cabin.
   String? cabinId;
 
-  /// The ID of the recurring booking, if this [Booking] is part of a series of
+  /// The [RecurringBooking] reference, if this [Booking] is part of a series of
   /// recurring bookings.
-  String? recurringBookingId;
+  RecurringBooking? recurringBooking;
 
   /// The occurrence number this [Booking] appears in the list of recurring
   /// bookings. E.g., the 2nd occurrence out of 5.
   int? recurringNumber;
-
-  /// The total times the recurring booking occurs.
-  int? recurringTotalTimes;
 
   /// Creates a new [Booking].
   Booking({
@@ -39,9 +37,8 @@ abstract class Booking extends DateRangeItem {
     this.description,
     this.isLocked = false,
     this.cabinId,
-    this.recurringBookingId,
+    this.recurringBooking,
     this.recurringNumber,
-    this.recurringTotalTimes,
   });
 
   /// Creates a new [Booking] from a JSON Map.

--- a/lib/src/model/booking/booking_manager.dart
+++ b/lib/src/model/booking/booking_manager.dart
@@ -99,9 +99,9 @@ class BookingManager with ChangeNotifier {
     return allBookingsOn(booking.dateOnly!)
             .where(
               (comparingBooking) =>
-                  (comparingBooking.recurringBookingId == null ||
-                      comparingBooking.recurringBookingId !=
-                          booking.recurringBookingId) &&
+                  (comparingBooking.recurringBooking?.id == null ||
+                      comparingBooking.recurringBooking?.id !=
+                          booking.recurringBooking?.id) &&
                   comparingBooking.id != booking.id,
             )
             .firstWhereOrNull(
@@ -272,8 +272,7 @@ class BookingManager with ChangeNotifier {
       bookings.firstWhere((booking) => booking.id == id);
 
   RecurringBooking recurringBookingFromId(String? id) => recurringBookings
-      .firstWhere((recurringBooking) => recurringBooking.id == id)
-    ..recurringBookingId = id;
+      .firstWhere((recurringBooking) => recurringBooking.id == id);
 
   List<Booking> searchBookings(String query, {int? limit}) {
     final results = <Booking>[];
@@ -323,7 +322,7 @@ class BookingManager with ChangeNotifier {
     recurringBookings
         .firstWhere(
           (comparingRecurringBooking) =>
-              recurringBooking.recurringBookingId ==
+              recurringBooking.recurringBooking.id ==
                   comparingRecurringBooking.id ||
               recurringBooking.id == comparingRecurringBooking.id,
         )

--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -86,8 +86,13 @@ class RecurringBooking extends Booking {
     );
   }
 
+  /// Override getter from [Booking] to prevent a circular reference to this
+  /// [RecurringBooking] at instantiation.
+  @override
+  RecurringBooking get recurringBooking => this;
+
   static bool isRecurringBooking(Booking? booking) =>
-      booking is RecurringBooking || booking!.recurringBookingId != null;
+      booking is RecurringBooking || booking!.recurringBooking?.id != null;
 
   @override
   Map<String, dynamic> toJson() => {
@@ -143,13 +148,13 @@ class RecurringBooking extends Booking {
   }
 
   SingleBooking asSingleBooking({bool linked = true}) => SingleBooking(
-        id: linked ? '$id-0' : (recurringBookingId ?? id),
+        id: linked ? '$id-0' : id,
         startDate: startDate,
         endDate: endDate,
         description: description,
         isLocked: isLocked,
         cabinId: cabinId,
-        recurringBookingId: linked ? id : null,
+        recurringBooking: linked ? this : null,
       );
 
   List<SingleBooking> get bookings {
@@ -163,9 +168,8 @@ class RecurringBooking extends Booking {
       runBookings.add(
         movedBooking
           ..id = '$id-$count'
-          ..recurringBookingId = id
-          ..recurringNumber = count
-          ..recurringTotalTimes = occurrences,
+          ..recurringBooking = this
+          ..recurringNumber = count,
       );
 
       runDate = runDate.add(periodicityDuration);

--- a/lib/src/model/booking/single_booking.dart
+++ b/lib/src/model/booking/single_booking.dart
@@ -8,9 +8,8 @@ class SingleBooking extends Booking {
     super.description,
     super.isLocked,
     super.cabinId,
-    super.recurringBookingId,
+    super.recurringBooking,
     super.recurringNumber,
-    super.recurringTotalTimes,
   });
 
   SingleBooking.fromJson(super.other) : super.fromJson();

--- a/lib/widgets/booking/booking_card.dart
+++ b/lib/widgets/booking/booking_card.dart
@@ -163,8 +163,8 @@ class _BookingCardInfo extends StatelessWidget {
           children: [
             if (isRecurring)
               Tooltip(
-                message:
-                    '${booking.recurringNumber}/${booking.recurringTotalTimes}',
+                message: '${booking.recurringNumber}/'
+                    '${booking.recurringBooking?.occurrences}',
                 child: Padding(
                   padding: const EdgeInsetsDirectional.only(end: 4),
                   child: Icon(Icons.repeat, size: 16, color: theme.hintColor),

--- a/lib/widgets/booking/booking_preview_panel_action_bar.dart
+++ b/lib/widgets/booking/booking_preview_panel_action_bar.dart
@@ -88,11 +88,9 @@ class _BookingPreviewEditIconButton extends StatelessWidget {
     final editedBooking = await showDialog<Booking>(
       context: context,
       builder: (context) => BookingDialog(
-        booking: (booking.recurringBookingId == null
-            ? booking
-            : cabinManager
-                .cabinFromId(cabin.id)
-                .recurringBookingFromId(booking.recurringBookingId!))
+        booking: (booking.recurringBooking != null
+            ? booking.recurringBooking!
+            : booking)
           ..cabinId = cabin.id,
       ),
     );
@@ -171,7 +169,7 @@ class _BookingPreviewDeleteIconButton extends StatelessWidget {
     if (RecurringBooking.isRecurringBooking(booking)) {
       cabinManager.removeRecurringBookingById(
         cabin.id,
-        booking.recurringBookingId,
+        booking.recurringBooking?.id,
       );
     } else {
       cabinManager.removeSingleBookingById(cabin.id, booking.id);


### PR DESCRIPTION
By using the referenced object instead of its UUID as an indirect identifier, we can get rid of expensive `findById` operations.