### PR TITLE
refactor(single_booking): replace `cabinId` with referenced instance

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -2,6 +2,7 @@ import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:cabin_booking/utils/time_of_day_extension.dart';
 import 'package:intl/intl.dart';
 
+import '../cabin/cabin.dart';
 import '../date/date_range_item.dart';
 import 'recurring_booking.dart';
 
@@ -18,8 +19,8 @@ abstract class Booking extends DateRangeItem {
   /// Whether this [Booking] represents a locked time slot.
   bool isLocked;
 
-  /// The ID of the booked Cabin.
-  String? cabinId;
+  /// The [Cabin] reference.
+  Cabin? cabin;
 
   /// The [RecurringBooking] reference, if this [Booking] is part of a series of
   /// recurring bookings.
@@ -36,7 +37,7 @@ abstract class Booking extends DateRangeItem {
     super.endDate,
     this.description,
     this.isLocked = false,
-    this.cabinId,
+    this.cabin,
     this.recurringBooking,
     this.recurringNumber,
   });
@@ -70,7 +71,7 @@ abstract class Booking extends DateRangeItem {
     DateTime? endDate,
     String? description,
     bool? isLocked,
-    String? cabinId,
+    Cabin? cabin,
   });
 
   @override

--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -19,7 +19,7 @@ abstract class Booking extends DateRangeItem {
   /// Whether this [Booking] represents a locked time slot.
   bool isLocked;
 
-  /// The [Cabin] reference.
+  /// The reference of the booked [Cabin].
   Cabin? cabin;
 
   /// The [RecurringBooking] reference, if this [Booking] is part of a series of

--- a/lib/src/model/booking/recurring_booking.dart
+++ b/lib/src/model/booking/recurring_booking.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart' show IterableExtension;
 
+import '../cabin/cabin.dart';
 import 'booking.dart';
 import 'single_booking.dart';
 
@@ -24,7 +25,7 @@ class RecurringBooking extends Booking {
     super.endDate,
     super.description,
     super.isLocked,
-    super.cabinId,
+    super.cabin,
     this.periodicity = Periodicity.weekly,
     this.repeatEvery = 1,
     DateTime? recurringEndDate,
@@ -78,7 +79,7 @@ class RecurringBooking extends Booking {
       endDate: booking.endDate,
       description: booking.description,
       isLocked: booking.isLocked,
-      cabinId: booking.cabinId,
+      cabin: booking.cabin,
       periodicity: periodicity,
       repeatEvery: repeatEvery,
       recurringEndDate: recurringEndDate,
@@ -153,7 +154,7 @@ class RecurringBooking extends Booking {
         endDate: endDate,
         description: description,
         isLocked: isLocked,
-        cabinId: cabinId,
+        cabin: cabin,
         recurringBooking: linked ? this : null,
       );
 
@@ -199,7 +200,7 @@ class RecurringBooking extends Booking {
     DateTime? endDate,
     String? description,
     bool? isLocked,
-    String? cabinId,
+    Cabin? cabin,
     Periodicity? periodicity,
     int? repeatEvery,
     DateTime? recurringEndDate,
@@ -211,7 +212,7 @@ class RecurringBooking extends Booking {
         endDate: endDate ?? this.endDate,
         description: description ?? this.description,
         isLocked: isLocked ?? this.isLocked,
-        cabinId: cabinId ?? this.cabinId,
+        cabin: cabin ?? this.cabin,
         periodicity: periodicity ?? this.periodicity,
         repeatEvery: repeatEvery ?? this.repeatEvery,
         recurringEndDate: recurringEndDate != null && occurrences == null

--- a/lib/src/model/booking/single_booking.dart
+++ b/lib/src/model/booking/single_booking.dart
@@ -1,3 +1,4 @@
+import '../cabin/cabin.dart';
 import 'booking.dart';
 
 class SingleBooking extends Booking {
@@ -7,7 +8,7 @@ class SingleBooking extends Booking {
     super.endDate,
     super.description,
     super.isLocked,
-    super.cabinId,
+    super.cabin,
     super.recurringBooking,
     super.recurringNumber,
   });
@@ -21,7 +22,7 @@ class SingleBooking extends Booking {
           endDate: booking.endDate,
           description: booking.description,
           isLocked: booking.isLocked,
-          cabinId: booking.cabinId,
+          cabin: booking.cabin,
         );
 
   @override
@@ -31,7 +32,7 @@ class SingleBooking extends Booking {
     DateTime? endDate,
     String? description,
     bool? isLocked,
-    String? cabinId,
+    Cabin? cabin,
   }) =>
       SingleBooking(
         id: id ?? super.id,
@@ -39,7 +40,7 @@ class SingleBooking extends Booking {
         endDate: endDate ?? endDate,
         description: description ?? this.description,
         isLocked: isLocked ?? this.isLocked,
-        cabinId: cabinId ?? this.cabinId,
+        cabin: cabin ?? this.cabin,
       );
 
   @override

--- a/lib/src/model/cabin/cabin.dart
+++ b/lib/src/model/cabin/cabin.dart
@@ -175,7 +175,7 @@ class Cabin extends Item {
   Iterable<Booking> searchBookings(String query, {int? limit}) =>
       _bookingManager
           .searchBookings(query, limit: limit)
-          .map((booking) => booking.copyWith(cabinId: id));
+          .map((booking) => booking.copyWith(cabin: this));
 
   @override
   String toString() => '$number';

--- a/lib/src/model/cabin/cabin_manager.dart
+++ b/lib/src/model/cabin/cabin_manager.dart
@@ -253,7 +253,7 @@ class CabinManager extends WritableManager<Set<Cabin>> with ChangeNotifier {
     SingleBooking booking, {
     bool notify = true,
   }) {
-    cabinFromId(booking.cabinId ?? cabinId).addSingleBooking(booking);
+    cabinFromId(booking.cabin?.id ?? cabinId).addSingleBooking(booking);
 
     if (notify) notifyListeners();
   }
@@ -263,7 +263,7 @@ class CabinManager extends WritableManager<Set<Cabin>> with ChangeNotifier {
     RecurringBooking recurringBooking, {
     bool notify = true,
   }) {
-    cabinFromId(recurringBooking.cabinId ?? cabinId)
+    cabinFromId(recurringBooking.cabin?.id ?? cabinId)
         .addRecurringBooking(recurringBooking);
 
     if (notify) notifyListeners();
@@ -274,11 +274,11 @@ class CabinManager extends WritableManager<Set<Cabin>> with ChangeNotifier {
     SingleBooking booking, {
     bool notify = true,
   }) {
-    if (booking.cabinId == null || booking.cabinId == cabinId) {
+    if (booking.cabin?.id == null || booking.cabin?.id == cabinId) {
       cabinFromId(cabinId).modifySingleBooking(booking);
     } else {
       cabinFromId(cabinId).removeSingleBookingById(booking.id);
-      cabinFromId(booking.cabinId).addSingleBooking(booking);
+      cabinFromId(booking.cabin?.id).addSingleBooking(booking);
     }
 
     if (notify) notifyListeners();
@@ -289,12 +289,12 @@ class CabinManager extends WritableManager<Set<Cabin>> with ChangeNotifier {
     RecurringBooking recurringBooking, {
     bool notify = true,
   }) {
-    if (recurringBooking.cabinId == null ||
-        recurringBooking.cabinId == cabinId) {
+    if (recurringBooking.cabin?.id == null ||
+        recurringBooking.cabin?.id == cabinId) {
       cabinFromId(cabinId).modifyRecurringBooking(recurringBooking);
     } else {
       cabinFromId(cabinId).removeRecurringBookingById(recurringBooking.id);
-      cabinFromId(recurringBooking.cabinId)
+      cabinFromId(recurringBooking.cabin?.id)
           .addRecurringBooking(recurringBooking);
     }
 

--- a/lib/utils/dialog.dart
+++ b/lib/utils/dialog.dart
@@ -15,11 +15,11 @@ Future<void> showNewBookingDialog({
 
   if (newBooking != null) {
     if (newBooking is RecurringBooking) {
-      return cabinManager.addRecurringBooking(newBooking.cabinId, newBooking);
+      return cabinManager.addRecurringBooking(newBooking.cabin?.id, newBooking);
     }
 
     if (newBooking is SingleBooking) {
-      return cabinManager.addSingleBooking(newBooking.cabinId, newBooking);
+      return cabinManager.addSingleBooking(newBooking.cabin?.id, newBooking);
     }
   }
 }

--- a/lib/widgets/booking/booking_floating_action_button.dart
+++ b/lib/widgets/booking/booking_floating_action_button.dart
@@ -39,7 +39,7 @@ class BookingFloatingActionButton extends StatelessWidget {
                         minutes: defaultSlotDuration.inMinutes,
                       ),
                     ),
-                    cabinId: cabinManager.cabins.first.id,
+                    cabin: cabinManager.cabins.first,
                     occurrences: 1,
                   ),
                   cabinManager: cabinManager,
@@ -64,7 +64,7 @@ class BookingFloatingActionButton extends StatelessWidget {
                       ),
                     ),
                     isLocked: true,
-                    cabinId: cabinManager.cabins.first.id,
+                    cabin: cabinManager.cabins.first,
                   ),
                   cabinManager: cabinManager,
                 );
@@ -89,7 +89,7 @@ class BookingFloatingActionButton extends StatelessWidget {
                     minutes: defaultSlotDuration.inMinutes,
                   ),
                 ),
-                cabinId: cabinManager.cabins.first.id,
+                cabin: cabinManager.cabins.first,
               ),
               cabinManager: cabinManager,
             );

--- a/lib/widgets/booking/booking_form.dart
+++ b/lib/widgets/booking/booking_form.dart
@@ -91,9 +91,10 @@ class _BookingFormState extends State<BookingForm> {
       child: Column(
         children: [
           CabinDropdown(
-            value: _booking.cabinId!,
+            value: _booking.cabin!.id,
             onChanged: (value) {
-              setState(() => _booking.cabinId = value);
+              if (value == null) return;
+              setState(() => _booking.cabin?.id = value);
             },
           ),
           const SizedBox(height: 24),
@@ -193,7 +194,7 @@ class _BookingFormState extends State<BookingForm> {
                         }
 
                         if (cabinManager
-                            .cabinFromId(_booking.cabinId)
+                            .cabinFromId(_booking.cabin?.id)
                             .bookingsOverlapWith(_booking)) {
                           return appLocalizations.occupied;
                         }
@@ -274,7 +275,7 @@ class _BookingFormState extends State<BookingForm> {
                         }
 
                         if (cabinManager
-                            .cabinFromId(_booking.cabinId)
+                            .cabinFromId(_booking.cabin?.id)
                             .bookingsOverlapWith(_booking)) {
                           return appLocalizations.occupied;
                         }

--- a/lib/widgets/booking/booking_preview_panel_action_bar.dart
+++ b/lib/widgets/booking/booking_preview_panel_action_bar.dart
@@ -91,7 +91,7 @@ class _BookingPreviewEditIconButton extends StatelessWidget {
         booking: (booking.recurringBooking != null
             ? booking.recurringBooking!
             : booking)
-          ..cabinId = cabin.id,
+          ..cabin = cabin,
       ),
     );
 

--- a/lib/widgets/booking/booking_preview_panel_action_bar.dart
+++ b/lib/widgets/booking/booking_preview_panel_action_bar.dart
@@ -85,13 +85,11 @@ class _BookingPreviewEditIconButton extends StatelessWidget {
   Future<void> _onEdit(BuildContext context) async {
     final cabinManager = Provider.of<CabinManager>(context, listen: false);
 
+    final initialBooking = booking.recurringBooking ?? booking;
     final editedBooking = await showDialog<Booking>(
       context: context,
       builder: (context) => BookingDialog(
-        booking: (booking.recurringBooking != null
-                ? booking.recurringBooking!
-                : booking)
-            .copyWith(cabin: cabin),
+        booking: initialBooking.copyWith(cabin: cabin),
       ),
     );
 

--- a/lib/widgets/booking/empty_booking_slot.dart
+++ b/lib/widgets/booking/empty_booking_slot.dart
@@ -108,7 +108,7 @@ class _EmptyBookingSlotActionable extends StatelessWidget {
               booking: SingleBooking(
                 startDate: startDate,
                 endDate: endDate,
-                cabinId: cabin.id,
+                cabin: cabin,
               ),
               cabinManager: cabinManager,
             );

--- a/lib/widgets/jump_bar/booking_search_result.dart
+++ b/lib/widgets/jump_bar/booking_search_result.dart
@@ -29,9 +29,9 @@ class BookingSearchResult extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SearchResultLabel(
-              label: booking.cabinId != null
+              label: booking.cabin != null
                   ? '${appLocalizations.cabin} '
-                      '${cabinManager.cabinFromId(booking.cabinId).number}'
+                      '${cabinManager.cabinFromId(booking.cabin?.id).number}'
                   : null,
               placeholder: appLocalizations.cabin,
             ),

--- a/lib/widgets/jump_bar/jump_bar.dart
+++ b/lib/widgets/jump_bar/jump_bar.dart
@@ -59,7 +59,7 @@ class _JumpBarState extends State<JumpBar> {
         .tokenize(TokenizedBooking.expressions(appLocalizations));
     final booking = TokenizedBooking.fromTokens(bookingTokens)
         .toSingleBooking(appLocalizations)
-        .copyWith(cabinId: cabin?.id);
+        .copyWith(cabin: cabin);
 
     final searchedBookings = Provider.of<CabinManager>(
       context,

--- a/lib/widgets/jump_bar/jump_bar_results.dart
+++ b/lib/widgets/jump_bar/jump_bar_results.dart
@@ -38,8 +38,7 @@ class JumpBarResults extends StatelessWidget {
               return showNewBookingDialog(
                 context: context,
                 booking: suggestedBooking!.copyWith(
-                  cabinId:
-                      suggestedBooking!.cabinId ?? cabinManager.cabins.first.id,
+                  cabin: suggestedBooking!.cabin ?? cabinManager.cabins.first,
                 ),
                 cabinManager: cabinManager,
               );


### PR DESCRIPTION
By using the referenced object instead of its UUID as an indirect identifier, we can get rid of expensive `findById` operations.