### PR TITLE
fix(single_booking): use correct `copyWith` default values

### DIFF
--- a/lib/src/model/booking/single_booking.dart
+++ b/lib/src/model/booking/single_booking.dart
@@ -35,8 +35,8 @@ class SingleBooking extends Booking {
   }) =>
       SingleBooking(
         id: id ?? super.id,
-        startDate: startDate ?? startDate,
-        endDate: endDate ?? endDate,
+        startDate: startDate ?? this.startDate,
+        endDate: endDate ?? this.endDate,
         description: description ?? this.description,
         isLocked: isLocked ?? this.isLocked,
         cabinId: cabinId ?? this.cabinId,


### PR DESCRIPTION
Addresses an issue introduced in #131

Relates to #162