### PR TITLE
fix(booking_preview_panel_action_bar): pass a copy of the booking object to `BookingDialog`

### DIFF
--- a/lib/widgets/booking/booking_preview_panel_action_bar.dart
+++ b/lib/widgets/booking/booking_preview_panel_action_bar.dart
@@ -89,9 +89,9 @@ class _BookingPreviewEditIconButton extends StatelessWidget {
       context: context,
       builder: (context) => BookingDialog(
         booking: (booking.recurringBooking != null
-            ? booking.recurringBooking!
-            : booking)
-          ..cabinId = cabin.id,
+                ? booking.recurringBooking!
+                : booking)
+            .copyWith(cabinId: cabin.id),
       ),
     );
 


### PR DESCRIPTION
After #163, when popping an already changed booking from the `BookingDialog`, changes persisted in the app’s state until it was refreshed—although no storage operation was run—due to changes done to the referenced `Booking` object.