### PR TITLE
feat(date_ranger): implement new `textualDateTime` methods

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -1,6 +1,4 @@
 import 'package:cabin_booking/utils/date_time_extension.dart';
-import 'package:cabin_booking/utils/time_of_day_extension.dart';
-import 'package:intl/intl.dart';
 
 import '../cabin/cabin.dart';
 import '../date/date_range_item.dart';
@@ -58,12 +56,6 @@ abstract class Booking extends DateRangeItem {
   /// Date only part of [startDate].
   DateTime? get dateOnly => startDate?.dateOnly;
 
-  String get timeRange => '${startTime!.format24Hour()}'
-      '–${endTime!.format24Hour()}';
-
-  String get dateTimeRange =>
-      '${DateFormat.yMd().format(dateOnly!)} $timeRange';
-
   @override
   Booking copyWith({
     String? id,
@@ -86,7 +78,7 @@ abstract class Booking extends DateRangeItem {
 
   @override
   String toString() =>
-      [if (isLocked) '🔒', description, dateTimeRange].join(' ');
+      [if (isLocked) '🔒', description, textualDateTime].join(' ');
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/model/date/date_ranger.dart
+++ b/lib/src/model/date/date_ranger.dart
@@ -143,7 +143,7 @@ mixin DateRanger {
     return endDate!.difference(startDate!);
   }
 
-  /// Returns the formatted date and time range of this [DateRanger].
+  /// Returns the formatted local date and time range of this [DateRanger].
   ///
   /// By default, [referenceDateTime] is set to [DateTime.now()] to whether
   /// show or hide the matching year.
@@ -208,9 +208,8 @@ mixin DateRanger {
     DateFormat? end,
     String separator = '–',
   }) {
-    final formattedStartDate =
-        startDate != null ? start?.format(startDate!) : null;
-    final formattedEndDate = endDate != null ? end?.format(endDate!) : null;
+    final formattedStartDate = _formatLocalDateTime(startDate, start);
+    final formattedEndDate = _formatLocalDateTime(endDate, end);
     final shouldWhitespace = formattedStartDate == null ||
         (formattedEndDate?.contains(RegExp(r'\s')) ?? true);
 
@@ -219,7 +218,10 @@ mixin DateRanger {
         '$formattedEndDate';
   }
 
-  /// Returns the formatted time range of this [DateRanger].
+  String? _formatLocalDateTime(DateTime? dateTime, DateFormat? dateFormat) =>
+      dateTime != null ? dateFormat?.format(dateTime.toLocal()) : null;
+
+  /// Returns the formatted local time range of this [DateRanger].
   ///
   /// Example:
   /// ```dart

--- a/lib/utils/time_of_day_extension.dart
+++ b/lib/utils/time_of_day_extension.dart
@@ -107,16 +107,6 @@ extension TimeOfDayExtension on TimeOfDay {
         minutes: minute.roundToNearest(n) - minute,
       );
 
-  /// Returns the 24-hour formatted string representation of this [TimeOfDay],
-  /// separated with ':'.
-  ///
-  /// Examples:
-  /// ```dart
-  /// assert(const TimeOfDay(hour: 9, minute: 00).format24Hour() == '09:00');
-  /// assert(const TimeOfDay(hour: 17, minute: 14).format24Hour() == '17:14');
-  /// ```
-  String format24Hour() => '${hour.padLeft2}:${minute.padLeft2}';
-
   // TODO(albertms10): remove when implemented in Flutter, https://github.com/flutter/flutter/pull/59981.
   static int compare(TimeOfDay a, TimeOfDay b) => a.compareTo(b);
 

--- a/lib/widgets/booking/booking_card.dart
+++ b/lib/widgets/booking/booking_card.dart
@@ -192,7 +192,7 @@ class _BookingCardInfo extends StatelessWidget {
                     ),
                     if (constraints.maxHeight > 30)
                       Text(
-                        booking.timeRange,
+                        booking.textualTime,
                         style: theme.textTheme.caption?.copyWith(
                           fontSize: constraints.maxHeight > 40
                               ? 14

--- a/lib/widgets/booking/booking_preview_panel.dart
+++ b/lib/widgets/booking/booking_preview_panel.dart
@@ -69,7 +69,7 @@ class _BookingPreviewPanelHeadline extends StatelessWidget {
               style: TextStyle(color: theme.hintColor),
             ),
           ),
-          Text(booking.timeRange),
+          Text(booking.textualTime),
         ],
       ),
     );

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -356,7 +356,7 @@ void main() {
     group('.textualDateTime()', () {
       test(
         'should return a textual range representation of a finite '
-        'DateRange with the same year',
+        'DateRanger with the same year',
         () {
           final dateRange = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
@@ -388,7 +388,7 @@ void main() {
 
       test(
         'should return a textual range representation of a finite '
-        'DateRange with the same year and day',
+        'DateRanger with the same year and day',
         () {
           final dateRange = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
@@ -433,11 +433,11 @@ void main() {
 
       test(
         'should return a textual range representation of a finite '
-        'DateRange with different years',
+        'DateRanger with different years',
         () {
           final dateRange = DateRange(
-            startDate: DateTime.utc(2022, 12, 1, 8, 30),
-            endDate: DateTime.utc(2023, 1, 12, 20, 30),
+            startDate: DateTime(2022, 12, 1, 9, 30),
+            endDate: DateTime(2023, 1, 12, 21, 30),
           );
           expect(
             dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
@@ -461,7 +461,7 @@ void main() {
 
       test(
         'should return a textual range representation of an infinite '
-        'DateRange',
+        'DateRanger',
         () {
           expect(DateRange.infinite.textualDateTime(), 'null – null');
 
@@ -485,7 +485,7 @@ void main() {
     });
 
     group('.textualTime', () {
-      test('should return the textual time range of a finite DateRange', () {
+      test('should return the textual time range of a finite DateRanger', () {
         final dateRange = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 1, 21, 30),
@@ -499,18 +499,39 @@ void main() {
         expect(multiYearDateRange.textualTime, '09:30–21:30');
       });
 
-      test('should return the textual time range of an infinite DateRange', () {
-        expect(DateRange.infinite.textualTime, 'null – null');
-        final dateRange = DateRange(
-          startDate: DateTime(2022, 12, 1, 9, 30),
-        );
-        expect(dateRange.textualTime, '09:30 – null');
+      test(
+        'should return the textual local time range of a UTC DateRanger',
+        () {
+          final dateRange = DateRange(
+            startDate: DateTime.utc(2022, 12, 1, 9, 30),
+            endDate: DateTime.utc(2022, 12, 1, 21, 45),
+          );
+          final startDate = dateRange.startDate!.toLocal();
+          final endDate = dateRange.endDate!.toLocal();
+          String padTime(int time) => '$time'.padLeft(2, '0');
+          expect(
+            dateRange.textualTime,
+            '${padTime(startDate.hour)}:${padTime(startDate.minute)}–'
+            '${padTime(endDate.hour)}:${padTime(endDate.minute)}',
+          );
+        },
+      );
 
-        final multiYearDateRange = DateRange(
-          endDate: DateTime(2023, 1, 12, 21, 30),
-        );
-        expect(multiYearDateRange.textualTime, 'null – 21:30');
-      });
+      test(
+        'should return the textual time range of an infinite DateRanger',
+        () {
+          expect(DateRange.infinite.textualTime, 'null – null');
+          final dateRange = DateRange(
+            startDate: DateTime(2022, 12, 1, 9, 30),
+          );
+          expect(dateRange.textualTime, '09:30 – null');
+
+          final multiYearDateRange = DateRange(
+            endDate: DateTime(2023, 1, 12, 21, 30),
+          );
+          expect(multiYearDateRange.textualTime, 'null – 21:30');
+        },
+      );
     });
 
     group('.hoursSpan', () {

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -436,8 +436,8 @@ void main() {
         'DateRange with different years',
         () {
           final dateRange = DateRange(
-            startDate: DateTime(2022, 12, 1, 9, 30),
-            endDate: DateTime(2023, 1, 12, 21, 30),
+            startDate: DateTime.utc(2022, 12, 1, 8, 30),
+            endDate: DateTime.utc(2023, 1, 12, 20, 30),
           );
           expect(
             dateRange.textualDateTime(referenceDateTime: DateTime(2022)),

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -353,6 +353,166 @@ void main() {
       });
     });
 
+    group('.textualDateTime()', () {
+      test(
+        'should return a textual range representation of a finite '
+        'DateRange with the same year',
+        () {
+          final dateRange = DateRange(
+            startDate: DateTime(2022, 12, 1, 9, 30),
+            endDate: DateTime(2022, 12, 31, 21, 30),
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
+            'December 1 09:30 – December 31 21:30',
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
+            'December 1, 2022 09:30 – December 31 21:30',
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
+            dateRange.textualDateTime(referenceDateTime: DateTime(2021)),
+          );
+          expect(
+            dateRange.textualDateTime(
+              referenceDateTime: DateTime(2023),
+              fullDateFormat: (format) => format.add_yMMMMEEEEd(),
+              monthDayFormat: (format) => format.add_LLL().add_d(),
+              timeFormat: (format) => format.add_Hms(),
+            ),
+            'Thursday, December 1, 2022 09:30:00 – Dec 31 21:30:00',
+          );
+        },
+      );
+
+      test(
+        'should return a textual range representation of a finite '
+        'DateRange with the same year and day',
+        () {
+          final dateRange = DateRange(
+            startDate: DateTime(2022, 12, 1, 9, 30),
+            endDate: DateTime(2022, 12, 1, 21, 30),
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
+            'December 1 09:30–21:30',
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
+            'December 1, 2022 09:30–21:30',
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
+            dateRange.textualDateTime(referenceDateTime: DateTime(2021)),
+          );
+          expect(
+            dateRange.textualDateTime(
+              referenceDateTime: DateTime(2022),
+              monthDayFormat: (format) => format.add_d().add_LLL(),
+              timeFormat: (format) => format.add_Hms(),
+            ),
+            '1 Dec 09:30:00–21:30:00',
+          );
+          expect(
+            dateRange.textualDateTime(
+              referenceDateTime: DateTime(2022),
+              monthDayFormat: (format) => format.add_MMMMEEEEd(),
+            ),
+            'Thursday, December 1 09:30–21:30',
+          );
+          expect(
+            dateRange.textualDateTime(
+              referenceDateTime: DateTime(2023),
+              fullDateFormat: (format) => format.add_yMMMMEEEEd(),
+            ),
+            'Thursday, December 1, 2022 09:30–21:30',
+          );
+        },
+      );
+
+      test(
+        'should return a textual range representation of a finite '
+        'DateRange with different years',
+        () {
+          final dateRange = DateRange(
+            startDate: DateTime(2022, 12, 1, 9, 30),
+            endDate: DateTime(2023, 1, 12, 21, 30),
+          );
+          expect(
+            dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
+            'December 1, 2022 09:30 – January 12, 2023 21:30',
+          );
+          expect(
+            dateRange.textualDateTime(
+              fullDateFormat: (format) => format.add_yMd(),
+            ),
+            '12/1/2022 09:30 – 1/12/2023 21:30',
+          );
+          expect(
+            dateRange.textualDateTime(
+              fullDateFormat: (format) => format.add_yMMMMEEEEd(),
+            ),
+            'Thursday, December 1, 2022 09:30 – '
+            'Thursday, January 12, 2023 21:30',
+          );
+        },
+      );
+
+      test(
+        'should return a textual range representation of an infinite '
+        'DateRange',
+        () {
+          expect(DateRange.infinite.textualDateTime(), 'null – null');
+
+          final startDateRange = DateRange(
+            startDate: DateTime(2022, 12, 1, 9, 30),
+          );
+          expect(
+            startDateRange.textualDateTime(),
+            'December 1, 2022 09:30 – null',
+          );
+
+          final endDateRange = DateRange(
+            endDate: DateTime(2022, 12, 31, 21, 30),
+          );
+          expect(
+            endDateRange.textualDateTime(),
+            'null – December 31, 2022 21:30',
+          );
+        },
+      );
+    });
+
+    group('.textualTime', () {
+      test('should return the textual time range of a finite DateRange', () {
+        final dateRange = DateRange(
+          startDate: DateTime(2022, 12, 1, 9, 30),
+          endDate: DateTime(2022, 12, 1, 21, 30),
+        );
+        expect(dateRange.textualTime, '09:30–21:30');
+
+        final multiYearDateRange = DateRange(
+          startDate: DateTime(2022, 12, 1, 9, 30),
+          endDate: DateTime(2023, 1, 12, 21, 30),
+        );
+        expect(multiYearDateRange.textualTime, '09:30–21:30');
+      });
+
+      test('should return the textual time range of an infinite DateRange', () {
+        expect(DateRange.infinite.textualTime, 'null – null');
+        final dateRange = DateRange(
+          startDate: DateTime(2022, 12, 1, 9, 30),
+        );
+        expect(dateRange.textualTime, '09:30 – null');
+
+        final multiYearDateRange = DateRange(
+          endDate: DateTime(2023, 1, 12, 21, 30),
+        );
+        expect(multiYearDateRange.textualTime, 'null – 21:30');
+      });
+    });
+
     group('.hoursSpan', () {
       test('should return a Map of the time span of this DateRanger', () {
         final dateRange = DateRange(

--- a/test/utils/time_of_day_extension_test.dart
+++ b/test/utils/time_of_day_extension_test.dart
@@ -188,14 +188,6 @@ void main() {
       });
     });
 
-    group('.format24Hour()', () {
-      test('should return a TimeOfDay in 24 hour format', () {
-        expect(const TimeOfDay(hour: 0, minute: 0).format24Hour(), '00:00');
-        expect(const TimeOfDay(hour: 9, minute: 41).format24Hour(), '09:41');
-        expect(const TimeOfDay(hour: 17, minute: 45).format24Hour(), '17:45');
-      });
-    });
-
     // TODO(albertms10): remove when implemented in Flutter, https://github.com/flutter/flutter/pull/59981.
     group('Comparable<TimeOfDay>', () {
       test('.compareTo()', () {


### PR DESCRIPTION
This PR aims to replace the `timeRange` and `dateTimeRange` methods from `Booking` with `textualTime` and `textualDateTime` in `DateRanger`, allowing custom date and time formats.

Additionally, the `TimeOfDayExtension.format24hour` method has been removed.