### PR TITLE
fix(booking): call `textualDateTime` method on `toString`

### DIFF
--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -78,7 +78,7 @@ abstract class Booking extends DateRangeItem {
 
   @override
   String toString() =>
-      [if (isLocked) '🔒', description, textualDateTime].join(' ');
+      [if (isLocked) '🔒', description, textualDateTime()].join(' ');
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/model/booking/booking.dart
+++ b/lib/src/model/booking/booking.dart
@@ -77,8 +77,12 @@ abstract class Booking extends DateRangeItem {
   }
 
   @override
-  String toString() =>
-      [if (isLocked) '🔒', description, textualDateTime()].join(' ');
+  String toString() => [
+        if (isLocked) '🔒',
+        description,
+        // A reference DateTime with year 0 will always show the year textually.
+        textualDateTime(referenceDateTime: DateTime(0)),
+      ].join(' ');
 
   @override
   bool operator ==(Object other) =>

--- a/test/model/booking/single_booking_test.dart
+++ b/test/model/booking/single_booking_test.dart
@@ -50,5 +50,29 @@ void main() {
         },
       );
     });
+
+    group('.toString()', () {
+      test('should return a string representation of a SingleBooking', () {
+        final booking = SingleBooking(
+          startDate: DateTime(2022, 12, 4, 9),
+          endDate: DateTime(2022, 12, 4, 10, 30),
+          description: 'Booked slot',
+        );
+        expect(booking.toString(), 'Booked slot December 4, 2022 09:00–10:30');
+      });
+
+      test(
+        'should return a string representation of a locked SingleBooking',
+        () {
+          final booking = SingleBooking(
+            startDate: DateTime(2023, 1, 12, 21, 15),
+            endDate: DateTime(2023, 1, 12, 22),
+            description: 'Slot',
+            isLocked: true,
+          );
+          expect(booking.toString(), '🔒 Slot January 12, 2023 21:15–22:00');
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
Addresses an issue introduced in #168