### PR TITLE
refactor(cabin): remove redirection methods to `BookingCollection`

### DIFF
--- a/lib/src/model/cabin/cabin.dart
+++ b/lib/src/model/cabin/cabin.dart
@@ -57,13 +57,6 @@ class Cabin extends Item {
 
   Cabin simplified() => Cabin(id: id, number: number);
 
-  Set<SingleBooking> get bookings => bookingCollection.bookings;
-
-  Set<RecurringBooking> get recurringBookings =>
-      bookingCollection.recurringBookings;
-
-  Set<Booking> get allBookings => bookingCollection.allBookings;
-
   @override
   Cabin copyWith({
     String? id,
@@ -76,8 +69,9 @@ class Cabin extends Item {
         id: id ?? this.id,
         number: number ?? this.number,
         elements: elements ?? this.elements,
-        bookings: bookings ?? this.bookings,
-        recurringBookings: recurringBookings ?? this.recurringBookings,
+        bookings: bookings ?? bookingCollection.bookings,
+        recurringBookings:
+            recurringBookings ?? bookingCollection.recurringBookings,
       );
 
   @override

--- a/lib/src/model/cabin/cabin.dart
+++ b/lib/src/model/cabin/cabin.dart
@@ -1,10 +1,7 @@
-import 'package:flutter/material.dart';
-
 import '../booking/booking.dart';
 import '../booking/recurring_booking.dart';
 import '../booking/single_booking.dart';
 import '../booking_collection.dart';
-import '../date/date_ranger.dart';
 import '../item.dart';
 import 'cabin_elements.dart';
 
@@ -19,7 +16,7 @@ abstract class _JsonFields {
 class Cabin extends Item {
   int number;
   late CabinElements elements;
-  final BookingCollection _bookingCollection;
+  final BookingCollection bookingCollection;
 
   /// Creates a new [Cabin].
   Cabin({
@@ -28,7 +25,7 @@ class Cabin extends Item {
     CabinElements? elements,
     Set<SingleBooking>? bookings,
     Set<RecurringBooking>? recurringBookings,
-  }) : _bookingCollection = BookingCollection(
+  }) : bookingCollection = BookingCollection(
           bookings: bookings,
           recurringBookings: recurringBookings,
         ) {
@@ -41,7 +38,7 @@ class Cabin extends Item {
         elements = CabinElements.fromJson(
           other[_JsonFields.elements] as Map<String, dynamic>,
         ),
-        _bookingCollection = BookingCollection.fromJson(
+        bookingCollection = BookingCollection.fromJson(
           bookings: other[_JsonFields.bookings] as List<dynamic>,
           recurringBookings:
               other[_JsonFields.recurringBookings] as List<dynamic>,
@@ -53,76 +50,19 @@ class Cabin extends Item {
         ...super.toJson(),
         _JsonFields.number: number,
         _JsonFields.elements: elements.toJson(),
-        _JsonFields.bookings: _bookingCollection.singleBookingsToJson(),
+        _JsonFields.bookings: bookingCollection.singleBookingsToJson(),
         _JsonFields.recurringBookings:
-            _bookingCollection.recurringBookingsToJson(),
+            bookingCollection.recurringBookingsToJson(),
       };
 
   Cabin simplified() => Cabin(id: id, number: number);
 
-  Set<SingleBooking> get bookings => _bookingCollection.bookings;
+  Set<SingleBooking> get bookings => bookingCollection.bookings;
 
   Set<RecurringBooking> get recurringBookings =>
-      _bookingCollection.recurringBookings;
+      bookingCollection.recurringBookings;
 
-  Set<Booking> get allBookings => _bookingCollection.allBookings;
-
-  Set<Booking> bookingsBetween(DateRanger dateRange) =>
-      _bookingCollection.singleBookingsBetween(dateRange);
-
-  Set<Booking> recurringBookingsBetween(DateRanger dateRange) =>
-      _bookingCollection.recurringBookingsBetween(dateRange);
-
-  List<Booking> get generatedBookingsFromRecurring =>
-      _bookingCollection.singleBookingsFromRecurring;
-
-  bool bookingsOverlapWith(Booking booking) =>
-      _bookingCollection.bookingsOverlapWith(booking);
-
-  Duration occupiedDuration({DateTime? dateTime, DateRanger? dateRange}) =>
-      _bookingCollection.occupiedDuration(
-        dateTime: dateTime,
-        dateRange: dateRange,
-      );
-
-  double occupancyPercentOn(
-    DateTime? dateTime, {
-    required TimeOfDay startTime,
-    required TimeOfDay endTime,
-  }) =>
-      _bookingCollection.occupancyPercentOn(
-        dateTime,
-        startTime: startTime,
-        endTime: endTime,
-      );
-
-  Set<DateTime> datesWithBookings([DateRanger? dateRange]) =>
-      _bookingCollection.datesWithBookings(dateRange);
-
-  Map<DateTime, int> get allBookingsCountPerDay =>
-      _bookingCollection.allBookingsCountPerDay;
-
-  Map<DateTime, Duration> occupiedDurationPerWeek([DateRanger? dateRange]) =>
-      _bookingCollection.occupiedDurationPerWeek(dateRange);
-
-  double occupancyPercent({
-    required TimeOfDay startTime,
-    required TimeOfDay endTime,
-    Set<DateTime>? dates,
-  }) =>
-      _bookingCollection.occupancyPercent(
-        startTime: startTime,
-        endTime: endTime,
-        dates: dates,
-      );
-
-  Map<TimeOfDay, Duration> accumulatedTimeRangesOccupancy([
-    DateRanger? dateRange,
-  ]) =>
-      _bookingCollection.accumulatedTimeRangesOccupancy(dateRange);
-
-  Set<TimeOfDay> mostOccupiedTimeRange([DateRanger? dateRange]) =>
-      _bookingCollection.mostOccupiedTimeRange(dateRange);
+  Set<Booking> get allBookings => bookingCollection.allBookings;
 
   @override
   Cabin copyWith({
@@ -148,37 +88,8 @@ class Cabin extends Item {
     super.replaceWith(item);
   }
 
-  void addSingleBooking(SingleBooking booking) =>
-      _bookingCollection.addSingleBooking(booking);
-
-  void addRecurringBooking(RecurringBooking recurringBooking) =>
-      _bookingCollection.addRecurringBooking(recurringBooking);
-
-  void modifySingleBooking(SingleBooking booking) =>
-      _bookingCollection.modifySingleBooking(booking);
-
-  void modifyRecurringBooking(RecurringBooking recurringBooking) =>
-      _bookingCollection.modifyRecurringBooking(recurringBooking);
-
-  void removeSingleBookingById(String? id) =>
-      _bookingCollection.removeSingleBookingById(id);
-
-  void removeRecurringBookingById(String? id) =>
-      _bookingCollection.removeRecurringBookingById(id);
-
-  void emptyAllBookings() => _bookingCollection.emptyAllBookings();
-
-  SingleBooking singleBookingFromId(String id) =>
-      _bookingCollection.singleBookingFromId(id);
-
-  RecurringBooking recurringBookingFromId(String id) =>
-      _bookingCollection.recurringBookingFromId(id);
-
-  Set<Booking> allBookingsOn(DateTime dateTime) =>
-      _bookingCollection.allBookingsOn(dateTime);
-
   Iterable<Booking> searchBookings(String query, {int? limit}) =>
-      _bookingCollection
+      bookingCollection
           .searchBookings(query, limit: limit)
           .map((booking) => booking.copyWith(cabin: this));
 

--- a/lib/src/model/cabin_collection.dart
+++ b/lib/src/model/cabin_collection.dart
@@ -102,7 +102,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     var count = 0;
 
     for (final cabin in cabins) {
-      count += cabin.allBookings.length;
+      count += cabin.bookingCollection.allBookings.length;
     }
 
     return count;
@@ -112,7 +112,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     var count = 0;
 
     for (final cabin in cabins) {
-      count += cabin.bookings.length;
+      count += cabin.bookingCollection.bookings.length;
     }
 
     return count;

--- a/lib/src/model/cabin_collection.dart
+++ b/lib/src/model/cabin_collection.dart
@@ -41,14 +41,16 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
 
   Set<DateTime> allCabinsDatesWithBookings([DateRanger? dateRange]) =>
       SplayTreeSet.of({
-        for (final cabin in cabins) ...cabin.datesWithBookings(dateRange),
+        for (final cabin in cabins)
+          ...cabin.bookingCollection.datesWithBookings(dateRange),
       });
 
   Map<DateTime, int> get allCabinsBookingsCountPerDay {
     final bookingsPerDay = <DateTime, int>{};
 
     for (final cabin in cabins) {
-      for (final bookingsCount in cabin.allBookingsCountPerDay.entries) {
+      for (final bookingsCount
+          in cabin.bookingCollection.allBookingsCountPerDay.entries) {
         bookingsPerDay.update(
           bookingsCount.key,
           (count) => count + bookingsCount.value,
@@ -77,7 +79,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
 
     for (final cabin in cabins) {
       final accumulatedTimeRanges =
-          cabin.accumulatedTimeRangesOccupancy(dateRange);
+          cabin.bookingCollection.accumulatedTimeRangesOccupancy(dateRange);
 
       for (final bookingTimeRange in accumulatedTimeRanges.entries) {
         timeRanges.update(
@@ -120,7 +122,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     var count = 0;
 
     for (final cabin in cabins) {
-      count += cabin.generatedBookingsFromRecurring.length;
+      count += cabin.bookingCollection.singleBookingsFromRecurring.length;
     }
 
     return count;
@@ -130,7 +132,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     var duration = Duration.zero;
 
     for (final cabin in cabins) {
-      duration += cabin.occupiedDuration(
+      duration += cabin.bookingCollection.occupiedDuration(
         dateTime: dateTime,
         dateRange: dateRange,
       );
@@ -143,7 +145,8 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     final bookingsPerDay = SplayTreeMap<DateTime, Duration>();
 
     for (final cabin in cabins) {
-      final occupiedDuration = cabin.occupiedDurationPerWeek(dateRange);
+      final occupiedDuration =
+          cabin.bookingCollection.occupiedDurationPerWeek(dateRange);
 
       for (final durationPerWeek in occupiedDuration.entries) {
         bookingsPerDay.update(
@@ -166,7 +169,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
 
     final percents = [
       for (final cabin in cabins)
-        cabin.occupancyPercent(
+        cabin.bookingCollection.occupancyPercent(
           startTime: startTime,
           endTime: endTime,
           dates: dates,
@@ -181,7 +184,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     var count = 0;
 
     for (final cabin in cabins) {
-      count += cabin.bookingsBetween(dateRange).length;
+      count += cabin.bookingCollection.singleBookingsBetween(dateRange).length;
     }
 
     return count;
@@ -191,7 +194,8 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     var count = 0;
 
     for (final cabin in cabins) {
-      count += cabin.recurringBookingsBetween(dateRange).length;
+      count +=
+          cabin.bookingCollection.recurringBookingsBetween(dateRange).length;
     }
 
     return count;
@@ -232,7 +236,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
   }) {
     cabins
         .where((cabin) => ids.contains(cabin.id))
-        .forEach((cabin) => cabin.emptyAllBookings());
+        .forEach((cabin) => cabin.bookingCollection.emptyAllBookings());
 
     if (notify) notifyListeners();
   }
@@ -251,7 +255,9 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     SingleBooking booking, {
     bool notify = true,
   }) {
-    cabinFromId(booking.cabin?.id ?? cabinId).addSingleBooking(booking);
+    cabinFromId(booking.cabin?.id ?? cabinId)
+        .bookingCollection
+        .addSingleBooking(booking);
 
     if (notify) notifyListeners();
   }
@@ -262,6 +268,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     bool notify = true,
   }) {
     cabinFromId(recurringBooking.cabin?.id ?? cabinId)
+        .bookingCollection
         .addRecurringBooking(recurringBooking);
 
     if (notify) notifyListeners();
@@ -273,10 +280,14 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     bool notify = true,
   }) {
     if (booking.cabin?.id == null || booking.cabin?.id == cabinId) {
-      cabinFromId(cabinId).modifySingleBooking(booking);
+      cabinFromId(cabinId).bookingCollection.modifySingleBooking(booking);
     } else {
-      cabinFromId(cabinId).removeSingleBookingById(booking.id);
-      cabinFromId(booking.cabin?.id).addSingleBooking(booking);
+      cabinFromId(cabinId)
+          .bookingCollection
+          .removeSingleBookingById(booking.id);
+      cabinFromId(booking.cabin?.id)
+          .bookingCollection
+          .addSingleBooking(booking);
     }
 
     if (notify) notifyListeners();
@@ -289,10 +300,15 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
   }) {
     if (recurringBooking.cabin?.id == null ||
         recurringBooking.cabin?.id == cabinId) {
-      cabinFromId(cabinId).modifyRecurringBooking(recurringBooking);
+      cabinFromId(cabinId)
+          .bookingCollection
+          .modifyRecurringBooking(recurringBooking);
     } else {
-      cabinFromId(cabinId).removeRecurringBookingById(recurringBooking.id);
+      cabinFromId(cabinId)
+          .bookingCollection
+          .removeRecurringBookingById(recurringBooking.id);
       cabinFromId(recurringBooking.cabin?.id)
+          .bookingCollection
           .addRecurringBooking(recurringBooking);
     }
 
@@ -304,7 +320,7 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     String? bookingId, {
     bool notify = true,
   }) {
-    cabinFromId(cabinId).removeSingleBookingById(bookingId);
+    cabinFromId(cabinId).bookingCollection.removeSingleBookingById(bookingId);
 
     if (notify) notifyListeners();
   }
@@ -314,7 +330,9 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
     String? bookingId, {
     bool notify = true,
   }) {
-    cabinFromId(cabinId).removeRecurringBookingById(bookingId);
+    cabinFromId(cabinId)
+        .bookingCollection
+        .removeRecurringBookingById(bookingId);
 
     if (notify) notifyListeners();
   }

--- a/lib/widgets/booking/booking_form.dart
+++ b/lib/widgets/booking/booking_form.dart
@@ -195,6 +195,7 @@ class _BookingFormState extends State<BookingForm> {
 
                         if (cabinCollection
                             .cabinFromId(_booking.cabin?.id)
+                            .bookingCollection
                             .bookingsOverlapWith(_booking)) {
                           return appLocalizations.occupied;
                         }
@@ -276,6 +277,7 @@ class _BookingFormState extends State<BookingForm> {
 
                         if (cabinCollection
                             .cabinFromId(_booking.cabin?.id)
+                            .bookingCollection
                             .bookingsOverlapWith(_booking)) {
                           return appLocalizations.occupied;
                         }

--- a/lib/widgets/booking/bookings_table.dart
+++ b/lib/widgets/booking/bookings_table.dart
@@ -42,7 +42,7 @@ class BookingsTable extends StatelessWidget {
                   child: BookingsStack(
                     key: Key('${cabin.number}'),
                     cabin: cabin.simplified(),
-                    bookings: cabin.allBookingsOn(dateTime),
+                    bookings: cabin.bookingCollection.allBookingsOn(dateTime),
                     showPreviewPanel: showPreviewPanel,
                     setPreventTimeTableScroll: setPreventTimeTableScroll,
                   ),

--- a/lib/widgets/cabin/cabins_table.dart
+++ b/lib/widgets/cabin/cabins_table.dart
@@ -35,15 +35,15 @@ class CabinsTable extends StatelessWidget {
                 item: cabin,
                 bookingsCount: cabin.bookings.length,
                 recurringBookingsCount:
-                    cabin.generatedBookingsFromRecurring.length,
-                occupiedDuration: cabin.occupiedDuration(),
+                    cabin.bookingCollection.singleBookingsFromRecurring.length,
+                occupiedDuration: cabin.bookingCollection.occupiedDuration(),
                 occupiedDurationPerWeek:
-                    cabin.occupiedDurationPerWeek(dateRange)
+                    cabin.bookingCollection.occupiedDurationPerWeek(dateRange)
                       ..fillEmptyKeyValues(
                         keys: keysToFill,
                         ifAbsent: () => Duration.zero,
                       ),
-                mostOccupiedTimeRanges: cabin
+                mostOccupiedTimeRanges: cabin.bookingCollection
                     .mostOccupiedTimeRange()
                     .compactConsecutive(
                       nextValue: (timeOfDay) => timeOfDay.increment(hours: 1),

--- a/lib/widgets/cabin/cabins_table.dart
+++ b/lib/widgets/cabin/cabins_table.dart
@@ -33,7 +33,7 @@ class CabinsTable extends StatelessWidget {
             for (final cabin in cabinCollection.cabins)
               ItemsTableRow<Cabin>(
                 item: cabin,
-                bookingsCount: cabin.bookings.length,
+                bookingsCount: cabin.bookingCollection.bookings.length,
                 recurringBookingsCount:
                     cabin.bookingCollection.singleBookingsFromRecurring.length,
                 occupiedDuration: cabin.bookingCollection.occupiedDuration(),

--- a/lib/widgets/layout/scrollable_time_table.dart
+++ b/lib/widgets/layout/scrollable_time_table.dart
@@ -110,7 +110,8 @@ class _ScrollablePanelOverlayTimeTableState
                           width: bookingStackWidth,
                           child: CabinIcon.progress(
                             number: cabin.number,
-                            progress: cabin.occupancyPercentOn(
+                            progress:
+                                cabin.bookingCollection.occupancyPercentOn(
                               widget.dateTime,
                               startTime: kTimeTableStartTime,
                               endTime: kTimeTableEndTime,

--- a/test/model/cabin/cabin_test.dart
+++ b/test/model/cabin/cabin_test.dart
@@ -129,8 +129,11 @@ void main() {
           expect(copiedCabin.id, 'copied-cabin');
           expect(copiedCabin.number, 2);
           expect(copiedCabin.elements, newCabinElements);
-          expect(copiedCabin.bookings, newBookings);
-          expect(copiedCabin.recurringBookings, newRecurringBookings);
+          expect(copiedCabin.bookingCollection.bookings, newBookings);
+          expect(
+            copiedCabin.bookingCollection.recurringBookings,
+            newRecurringBookings,
+          );
         },
       );
     });


### PR DESCRIPTION
This PR aims to reduce code complexity by publicly exposing the `Cabin.bookingCollection` member and removing unnecessary redirection methods in the `Cabin` class, improving code maintainability and discoverability.