### PR TITLE
refactor(cabin): expose `BookingCollection` from constructor

### DIFF
--- a/lib/src/model/cabin/cabin.dart
+++ b/lib/src/model/cabin/cabin.dart
@@ -1,6 +1,4 @@
 import '../booking/booking.dart';
-import '../booking/recurring_booking.dart';
-import '../booking/single_booking.dart';
 import '../booking_collection.dart';
 import '../item.dart';
 import 'cabin_elements.dart';
@@ -23,14 +21,9 @@ class Cabin extends Item {
     super.id,
     this.number = 0,
     CabinElements? elements,
-    Set<SingleBooking>? bookings,
-    Set<RecurringBooking>? recurringBookings,
-  }) : bookingCollection = BookingCollection(
-          bookings: bookings,
-          recurringBookings: recurringBookings,
-        ) {
-    this.elements = elements ?? CabinElements();
-  }
+    BookingCollection? bookingCollection,
+  })  : elements = elements ?? CabinElements(),
+        bookingCollection = bookingCollection ?? BookingCollection();
 
   /// Creates a new [Cabin] from a JSON Map.
   Cabin.fromJson(super.other)
@@ -62,16 +55,13 @@ class Cabin extends Item {
     String? id,
     int? number,
     CabinElements? elements,
-    Set<SingleBooking>? bookings,
-    Set<RecurringBooking>? recurringBookings,
+    BookingCollection? bookingCollection,
   }) =>
       Cabin(
         id: id ?? this.id,
         number: number ?? this.number,
         elements: elements ?? this.elements,
-        bookings: bookings ?? bookingCollection.bookings,
-        recurringBookings:
-            recurringBookings ?? bookingCollection.recurringBookings,
+        bookingCollection: bookingCollection ?? this.bookingCollection,
       );
 
   @override

--- a/test/model/cabin/cabin_test.dart
+++ b/test/model/cabin/cabin_test.dart
@@ -33,8 +33,10 @@ void main() {
               lecterns: 2,
               tables: 1,
             ),
-            bookings: {},
-            recurringBookings: {},
+            bookingCollection: BookingCollection(
+              bookings: {},
+              recurringBookings: {},
+            ),
           ),
         );
       });
@@ -76,12 +78,14 @@ void main() {
             lecterns: 2,
             tables: 1,
           ),
-          bookings: {
-            SingleBooking(id: 'booking-id'),
-          },
-          recurringBookings: {
-            RecurringBooking(id: 'recurring-booking-id', occurrences: 1),
-          },
+          bookingCollection: BookingCollection(
+            bookings: {
+              SingleBooking(id: 'booking-id'),
+            },
+            recurringBookings: {
+              RecurringBooking(id: 'recurring-booking-id', occurrences: 1),
+            },
+          ),
         );
         expect(cabin, cabin.copyWith());
         expect(identical(cabin, cabin.copyWith()), isFalse);
@@ -100,40 +104,39 @@ void main() {
               lecterns: 2,
               tables: 1,
             ),
-            bookings: {
-              SingleBooking(id: 'booking-id'),
-            },
-            recurringBookings: {
-              RecurringBooking(id: 'recurring-booking-id', occurrences: 1),
-            },
+            bookingCollection: BookingCollection(
+              bookings: {
+                SingleBooking(id: 'booking-id'),
+              },
+              recurringBookings: {
+                RecurringBooking(id: 'recurring-booking-id', occurrences: 1),
+              },
+            ),
           );
           final newCabinElements = CabinElements(
             pianos: const [Piano(brand: 'Bösendorfer', model: 'Imperial')],
             lecterns: 1,
             tables: 3,
           );
-          final newBookings = {
-            SingleBooking(id: 'booking-id-1'),
-            SingleBooking(id: 'booking-id-2'),
-          };
-          final newRecurringBookings = {
-            RecurringBooking(id: 'recurring-booking-id-1', occurrences: 2),
-          };
+          final newBookingCollection = BookingCollection(
+            bookings: {
+              SingleBooking(id: 'booking-id-1'),
+              SingleBooking(id: 'booking-id-2'),
+            },
+            recurringBookings: {
+              RecurringBooking(id: 'recurring-booking-id-1', occurrences: 2),
+            },
+          );
           final copiedCabin = cabin.copyWith(
             id: 'copied-cabin',
             number: 2,
             elements: newCabinElements,
-            bookings: newBookings,
-            recurringBookings: newRecurringBookings,
+            bookingCollection: newBookingCollection,
           );
           expect(copiedCabin.id, 'copied-cabin');
           expect(copiedCabin.number, 2);
           expect(copiedCabin.elements, newCabinElements);
-          expect(copiedCabin.bookingCollection.bookings, newBookings);
-          expect(
-            copiedCabin.bookingCollection.recurringBookings,
-            newRecurringBookings,
-          );
+          expect(copiedCabin.bookingCollection, newBookingCollection);
         },
       );
     });


### PR DESCRIPTION
Taking advantage of the work in #175, this PR aims to expose the `BookingCollection` member from within the `Cabin` constructor.