### PR TITLE
fix(date_ranger): exclude `endDate` instant in `includes`

### DIFF
--- a/lib/src/model/date/date_ranger.dart
+++ b/lib/src/model/date/date_ranger.dart
@@ -45,7 +45,8 @@ mixin DateRanger {
     return false;
   }
 
-  /// Whether [dateTime] is included in this [DateRanger].
+  /// Whether [dateTime] is included in this [DateRanger], including the
+  /// [startDate] but excluding the [endDate] instant: `[startDate, endDate)`.
   ///
   /// Examples:
   /// ```dart
@@ -55,9 +56,14 @@ mixin DateRanger {
   bool includes(DateTime dateTime) {
     if (hasInfiniteStart && hasInfiniteEnd) return true;
     if (hasInfiniteStart) return endDate!.isAfter(dateTime);
-    if (hasInfiniteEnd) return startDate!.isBefore(dateTime);
+    if (hasInfiniteEnd) {
+      return startDate!.isAtSameMomentAs(dateTime) ||
+          startDate!.isBefore(dateTime);
+    }
 
-    return startDate!.isBefore(dateTime) && endDate!.isAfter(dateTime);
+    return (startDate!.isAtSameMomentAs(dateTime) ||
+            startDate!.isBefore(dateTime)) &&
+        endDate!.isAfter(dateTime);
   }
 
   /// Whether this [DateRanger] overlaps with another [DateRanger].

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -107,21 +107,21 @@ void main() {
       test(
         'should return true when the DateTime is included in this DateRanger',
         () {
-          final dateTime = DateTime(2022, 12, 4, 11, 30);
+          final startDateTime = DateTime(2022, 12, 1, 9, 30);
+          final endDateTime = DateTime(2022, 12, 31, 21, 30);
           final dateRange = DateRange(
-            startDate: DateTime(2022, 12, 1, 9, 30),
-            endDate: DateTime(2022, 12, 31, 21, 30),
+            startDate: startDateTime,
+            endDate: endDateTime,
           );
+          expect(dateRange.includes(startDateTime), isTrue);
+          expect(dateRange.includes(endDateTime), isFalse);
+          final dateTime = DateTime(2022, 12, 4, 11, 30);
           expect(dateRange.includes(dateTime), isTrue);
 
-          final startDateRange = DateRange(
-            startDate: DateTime(2022, 12, 1, 9, 30),
-          );
+          final startDateRange = DateRange(startDate: startDateTime);
           expect(startDateRange.includes(dateTime), isTrue);
 
-          final endDateRange = DateRange(
-            endDate: DateTime(2022, 12, 31, 21, 30),
-          );
+          final endDateRange = DateRange(endDate: endDateTime);
           expect(endDateRange.includes(dateTime), isTrue);
         },
       );


### PR DESCRIPTION
This PR aims to exclude the `endDate` instant in the `DateRanger.includes` method, as would have been expected as a known convention.