### PR TITLE
refactor(school_year): use `textualDateTime` for `toString`

### DIFF
--- a/lib/src/model/school_year/school_year.dart
+++ b/lib/src/model/school_year/school_year.dart
@@ -1,7 +1,5 @@
 import 'dart:collection' show SplayTreeSet;
 
-import 'package:intl/intl.dart';
-
 import '../date/date_range_item.dart';
 import '../date/holiday.dart';
 
@@ -65,18 +63,10 @@ class SchoolYear extends DateRangeItem {
   }
 
   @override
-  String toString() {
-    final bothExist = startDate != null && endDate != null;
-    final isSameYear = bothExist && startDate!.year == endDate!.year;
-
-    final startYear =
-        startDate != null ? DateFormat.y().format(startDate!) : '';
-
-    final endYear =
-        endDate != null && !isSameYear ? DateFormat.y().format(endDate!) : '';
-
-    return '$startYear'
-        '${bothExist && !isSameYear ? '–' : ''}'
-        '$endYear';
-  }
+  String toString() => textualDateTime(
+        referenceDateTime: DateTime(0),
+        fullDateFormat: (format) => format.add_y(),
+        monthDayFormat: (format) => format.add_y(),
+        timeFormat: (format) => format,
+      );
 }

--- a/test/model/school_year/school_year_test.dart
+++ b/test/model/school_year/school_year_test.dart
@@ -74,5 +74,118 @@ void main() {
         expect(SchoolYear.fromJson(rawSchoolYear).toJson(), rawSchoolYear);
       });
     });
+
+    group('.holidaysDuration', () {
+      test('should return the correct duration for the holidays', () {
+        final schoolYear = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2023, 6, 23),
+          holidays: {
+            Holiday(
+              startDate: DateTime.utc(2022, 9, 11),
+              endDate: DateTime.utc(2022, 9, 12),
+              kind: HolidayKind.festivity,
+            ),
+            Holiday(
+              startDate: DateTime.utc(2022, 12, 7),
+              endDate: DateTime.utc(2022, 12, 8),
+              kind: HolidayKind.freeDisposal,
+            ),
+          },
+        );
+        expect(schoolYear.holidaysDuration, const Duration(days: 2));
+      });
+
+      test('should return no duration when no holidays are present', () {
+        final schoolYear = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2023, 6, 23),
+        );
+        expect(schoolYear.holidaysDuration, Duration.zero);
+      });
+    });
+
+    group('.workingDuration', () {
+      test('should return the correct working duration', () {
+        final schoolYear = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2022, 9, 15),
+          holidays: {
+            Holiday(
+              startDate: DateTime.utc(2022, 9, 11),
+              endDate: DateTime.utc(2022, 9, 12),
+              kind: HolidayKind.festivity,
+            ),
+          },
+        );
+        expect(schoolYear.workingDuration, const Duration(days: 3));
+      });
+
+      test(
+        'should return the correct working duration when no holidays are '
+        'present',
+        () {
+          final schoolYear = SchoolYear(
+            startDate: DateTime.utc(2022, 9, 11),
+            endDate: DateTime.utc(2022, 9, 15),
+          );
+          expect(schoolYear.workingDuration, schoolYear.duration);
+        },
+      );
+    });
+
+    group('.isOnHolidays()', () {
+      test('should return whether a DateTime is on holidays', () {
+        final schoolYear = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2023, 6, 23),
+          holidays: {
+            Holiday(
+              startDate: DateTime.utc(2022, 9, 11),
+              endDate: DateTime.utc(2022, 9, 12),
+              kind: HolidayKind.festivity,
+            ),
+            Holiday(
+              startDate: DateTime.utc(2022, 12, 7),
+              endDate: DateTime.utc(2022, 12, 8),
+              kind: HolidayKind.freeDisposal,
+            ),
+          },
+        );
+        expect(schoolYear.isOnHolidays(DateTime.utc(2022, 9, 11)), isTrue);
+        expect(schoolYear.isOnHolidays(DateTime.utc(2022, 9, 12)), isFalse);
+        expect(schoolYear.isOnHolidays(DateTime.utc(2022, 10)), isFalse);
+      });
+
+      test('should return false when no holidays are present', () {
+        final schoolYear = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2023, 6, 23),
+        );
+        expect(schoolYear.isOnHolidays(DateTime.utc(2022, 9, 12)), isFalse);
+      });
+    });
+
+    group('.toString()', () {
+      test('should return a string representation of this SchoolYear', () {
+        final schoolYear = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2023, 6, 23),
+        );
+        expect(schoolYear.toString(), '2022–2023');
+
+        final schoolYearTwo = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2024, 6, 23),
+        );
+        expect(schoolYearTwo.toString(), '2022–2024');
+
+        final schoolYearSame = SchoolYear(
+          startDate: DateTime.utc(2022, 9, 11),
+          endDate: DateTime.utc(2022, 10, 11),
+        );
+        expect(schoolYearSame.toString(), '2022–2022');
+      });
+    });
   });
 }


### PR DESCRIPTION
This PR aims to reuse the `textualDateTime` method in `SchoolYear.toString`, adding its corresponding test cases and for most `SchoolYear` methods.