### PR TITLE
refactor(model): move constructor bodies to initializer list

### DIFF
--- a/lib/src/model/booking_collection.dart
+++ b/lib/src/model/booking_collection.dart
@@ -18,10 +18,8 @@ class BookingCollection with ChangeNotifier {
   BookingCollection({
     Set<SingleBooking>? bookings,
     Set<RecurringBooking>? recurringBookings,
-  }) {
-    this.bookings = bookings ?? SplayTreeSet();
-    this.recurringBookings = recurringBookings ?? SplayTreeSet();
-  }
+  })  : bookings = bookings ?? SplayTreeSet(),
+        recurringBookings = recurringBookings ?? SplayTreeSet();
 
   BookingCollection.fromJson({
     required List<dynamic> bookings,

--- a/lib/src/model/cabin_collection.dart
+++ b/lib/src/model/cabin_collection.dart
@@ -24,9 +24,8 @@ class CabinCollection extends WritableManager<Set<Cabin>> with ChangeNotifier {
   late Set<Cabin> cabins;
 
   CabinCollection({Set<Cabin>? cabins, String fileName = 'cabins'})
-      : super(fileName) {
-    this.cabins = cabins ?? SplayTreeSet();
-  }
+      : cabins = cabins ?? SplayTreeSet(),
+        super(fileName);
 
   List<Map<String, dynamic>> cabinsToJson() =>
       cabins.map((cabin) => cabin.toJson()).toList();

--- a/lib/src/model/date/day_handler.dart
+++ b/lib/src/model/date/day_handler.dart
@@ -7,8 +7,8 @@ class DayHandler with ChangeNotifier {
   late DateTime _dateTime;
   late SchoolYearCollection schoolYearCollection;
 
-  DayHandler([SchoolYearCollection? schoolYearCollection]) {
-    _dateTime = DateTime.now();
+  DayHandler([SchoolYearCollection? schoolYearCollection])
+      : _dateTime = DateTime.now() {
     this.schoolYearCollection = schoolYearCollection ??
         SchoolYearCollection(notifyExternalListeners: notifyListeners);
   }

--- a/lib/src/model/item.dart
+++ b/lib/src/model/item.dart
@@ -26,10 +26,9 @@ abstract class Item implements Comparable<Item>, Serializable {
 
   /// Creates a new [Item].
   Item({String? id})
-      : creationDateTime = DateTime.now(),
-        modificationCount = 0 {
-    this.id = id ?? nanoid();
-  }
+      : id = id ?? nanoid(),
+        creationDateTime = DateTime.now(),
+        modificationCount = 0;
 
   /// Creates a new [Item] from a JSON Map.
   Item.fromJson(Map<String, dynamic> other)

--- a/lib/src/model/school_year/school_year.dart
+++ b/lib/src/model/school_year/school_year.dart
@@ -8,16 +8,14 @@ abstract class _JsonFields {
 }
 
 class SchoolYear extends DateRangeItem {
-  late Set<Holiday> holidays;
+  final Set<Holiday> holidays;
 
   SchoolYear({
     super.id,
     super.startDate,
     super.endDate,
     Set<Holiday>? holidays,
-  }) {
-    this.holidays = holidays ?? SplayTreeSet();
-  }
+  }) : holidays = holidays ?? SplayTreeSet();
 
   SchoolYear.fromJson(super.other)
       : holidays = SplayTreeSet.of(

--- a/lib/src/model/school_year_collection.dart
+++ b/lib/src/model/school_year_collection.dart
@@ -23,8 +23,8 @@ class SchoolYearCollection extends WritableManager<Set<SchoolYear>>
     Set<SchoolYear>? schoolYears,
     String fileName = 'school_years',
     this.notifyExternalListeners,
-  }) : super(fileName) {
-    this.schoolYears = schoolYears ?? SplayTreeSet();
+  })  : schoolYears = schoolYears ?? SplayTreeSet(),
+        super(fileName) {
     schoolYearIndex = _currentSchoolYearIndex;
   }
 


### PR DESCRIPTION
This PR aims to consistently use initializer lists instead of constructor bodies where possible.