### PR TITLE
refactor(booking_card): rewrite Widgets to allow a flexible composition

### DIFF
--- a/lib/widgets/booking/booking_card.dart
+++ b/lib/widgets/booking/booking_card.dart
@@ -1,9 +1,10 @@
 import 'package:cabin_booking/constants.dart';
 import 'package:cabin_booking/model.dart';
+import 'package:cabin_booking/widgets/booking/booking_card_info.dart';
+import 'package:cabin_booking/widgets/booking/booking_card_layout.dart';
 import 'package:cabin_booking/widgets/booking/booking_preview_panel_overlay.dart';
 import 'package:cabin_booking/widgets/layout/scrollable_time_table.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:timer_builder/timer_builder.dart';
 
 class BookingCard extends StatelessWidget {
@@ -20,11 +21,12 @@ class BookingCard extends StatelessWidget {
     this.setPreventTimeTableScroll,
   });
 
-  double get height => booking.duration.inMinutes * kBookingHeightRatio - 16;
+  static double heightFromDuration(Duration duration) =>
+      duration.inMinutes * kBookingHeightRatio - 16;
 
   @override
   Widget build(BuildContext context) {
-    final isBeforeNow = booking.endDate!.isBefore(DateTime.now());
+    final height = heightFromDuration(booking.duration);
 
     return TimerBuilder.periodic(
       const Duration(minutes: 1),
@@ -34,48 +36,15 @@ class BookingCard extends StatelessWidget {
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeInOutCubic,
           builder: (context, value, child) {
-            return Card(
-              shadowColor: isBeforeNow ? Colors.black38 : Colors.black87,
-              elevation: 0,
-              shape: RoundedRectangleBorder(
-                side: BorderSide(
-                  color: Colors.grey[300]!.withOpacity(isBeforeNow ? 0.41 : 1),
-                  width: 1.5,
-                ),
-                borderRadius: const BorderRadius.all(Radius.circular(10)),
-              ),
-              margin: const EdgeInsets.all(8),
-              child: Container(
-                decoration: booking.isLocked
-                    ? BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        gradient: const LinearGradient(
-                          begin: AlignmentDirectional.topStart,
-                          end: Alignment(-0.4, -0.2),
-                          colors: [
-                            Color.fromARGB(16, 0, 0, 0),
-                            Color.fromARGB(16, 0, 0, 0),
-                            Colors.white10,
-                            Colors.white10,
-                          ],
-                          stops: [0, 0.5, 0.5, 1],
-                          tileMode: TileMode.repeated,
-                        ),
-                      )
-                    : BoxDecoration(
-                        color: Theme.of(context)
-                            .cardColor
-                            .withOpacity(isBeforeNow ? 0.41 : 1),
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                height: height,
-                child: _BookingCardInteractive(
-                  cabin: cabin,
-                  booking: booking,
-                  height: value,
-                  showPreviewPanel: showPreviewPanel,
-                  setPreventTimeTableScroll: setPreventTimeTableScroll,
-                ),
+            return BookingCardLayout(
+              booking: booking,
+              height: height,
+              child: _BookingCardInteractive(
+                cabin: cabin,
+                booking: booking,
+                showPreviewPanel: showPreviewPanel,
+                setPreventTimeTableScroll: setPreventTimeTableScroll,
+                child: BookingCardInfo(cabin: cabin, booking: booking),
               ),
             );
           },
@@ -85,10 +54,10 @@ class BookingCard extends StatelessWidget {
   }
 }
 
-class _BookingCardInteractive extends StatefulWidget {
+class _BookingCardInteractive extends StatelessWidget {
   final Cabin cabin;
   final Booking booking;
-  final double height;
+  final Widget child;
   final ShowPreviewOverlayCallback? showPreviewPanel;
   final SetPreventTimeTableScroll? setPreventTimeTableScroll;
 
@@ -96,18 +65,11 @@ class _BookingCardInteractive extends StatefulWidget {
     super.key,
     required this.cabin,
     required this.booking,
-    required this.height,
+    required this.child,
     this.showPreviewPanel,
     this.setPreventTimeTableScroll,
   });
 
-  bool get isRecurring => RecurringBooking.isRecurringBooking(booking);
-
-  @override
-  _BookingCardInteractiveState createState() => _BookingCardInteractiveState();
-}
-
-class _BookingCardInteractiveState extends State<_BookingCardInteractive> {
   @override
   Widget build(BuildContext context) {
     return Material(
@@ -116,96 +78,18 @@ class _BookingCardInteractiveState extends State<_BookingCardInteractive> {
         onTap: () {
           final renderBox = context.findRenderObject() as RenderBox?;
           if (renderBox == null) return;
-          widget.showPreviewPanel?.call(
-            widget.cabin,
-            widget.booking,
+          showPreviewPanel?.call(
+            cabin,
+            booking,
             renderBox,
-            widget.setPreventTimeTableScroll,
+            setPreventTimeTableScroll,
           );
         },
         customBorder: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(10)),
         ),
-        child: Padding(
-          padding: const EdgeInsetsDirectional.only(start: 10, top: 8, end: 4),
-          child: _BookingCardInfo(
-            cabin: widget.cabin,
-            booking: widget.booking,
-            isRecurring: widget.isRecurring,
-          ),
-        ),
+        child: child,
       ),
-    );
-  }
-}
-
-class _BookingCardInfo extends StatelessWidget {
-  final Cabin cabin;
-  final Booking booking;
-  final bool isRecurring;
-
-  const _BookingCardInfo({
-    super.key,
-    required this.cabin,
-    required this.booking,
-    this.isRecurring = false,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final appLocalizations = AppLocalizations.of(context)!;
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (isRecurring)
-              Tooltip(
-                message: '${booking.recurringNumber}/'
-                    '${booking.recurringBooking?.occurrences}',
-                child: Padding(
-                  padding: const EdgeInsetsDirectional.only(end: 4),
-                  child: Icon(Icons.repeat, size: 16, color: theme.hintColor),
-                ),
-              ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsetsDirectional.only(end: 28),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Text(
-                      !booking.isLocked
-                          ? booking.description!
-                          : '${booking.description} '
-                              '(${appLocalizations.locked.toLowerCase()})',
-                      style: TextStyle(
-                        fontSize: constraints.maxHeight > 20
-                            ? 14
-                            : constraints.maxHeight * 0.5,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 4,
-                    ),
-                    if (constraints.maxHeight > 30)
-                      Text(
-                        booking.textualTime,
-                        style: theme.textTheme.caption?.copyWith(
-                          fontSize: constraints.maxHeight > 40
-                              ? 14
-                              : constraints.maxHeight * 0.4,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        );
-      },
     );
   }
 }

--- a/lib/widgets/booking/booking_card_info.dart
+++ b/lib/widgets/booking/booking_card_info.dart
@@ -1,0 +1,76 @@
+import 'package:cabin_booking/model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class BookingCardInfo extends StatelessWidget {
+  final Cabin cabin;
+  final Booking booking;
+
+  const BookingCardInfo({
+    super.key,
+    required this.cabin,
+    required this.booking,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final appLocalizations = AppLocalizations.of(context)!;
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(start: 10, top: 8, end: 4),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (RecurringBooking.isRecurringBooking(booking))
+                Tooltip(
+                  message: '${booking.recurringNumber}/'
+                      '${booking.recurringBooking?.occurrences}',
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.only(end: 4),
+                    child: Icon(Icons.repeat, size: 16, color: theme.hintColor),
+                  ),
+                ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsetsDirectional.only(end: 28),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        !booking.isLocked
+                            ? booking.description!
+                            : '${booking.description} '
+                                '(${appLocalizations.locked.toLowerCase()})',
+                        style: TextStyle(
+                          fontSize: constraints.maxHeight > 20
+                              ? 14
+                              : constraints.maxHeight * 0.5,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 4,
+                      ),
+                      if (constraints.maxHeight > 30)
+                        Text(
+                          booking.textualTime,
+                          style: theme.textTheme.caption?.copyWith(
+                            fontSize: constraints.maxHeight > 40
+                                ? 14
+                                : constraints.maxHeight * 0.4,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/booking/booking_card_layout.dart
+++ b/lib/widgets/booking/booking_card_layout.dart
@@ -1,0 +1,66 @@
+import 'package:cabin_booking/src/model/booking/booking.dart';
+import 'package:flutter/material.dart';
+
+class BookingCardLayout extends StatelessWidget {
+  final Booking booking;
+  final double? width;
+  final double? height;
+  final double elevation;
+  final Widget? child;
+
+  const BookingCardLayout({
+    super.key,
+    required this.booking,
+    this.width,
+    required this.height,
+    this.elevation = 0,
+    this.child,
+  });
+
+  static const double outerInset = 8;
+
+  @override
+  Widget build(BuildContext context) {
+    final isBeforeNow = booking.endDate!.isBefore(DateTime.now());
+
+    return Card(
+      shadowColor: isBeforeNow ? Colors.black38 : Colors.black87,
+      elevation: elevation,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(
+          color: Colors.grey[300]!.withOpacity(isBeforeNow ? 0.41 : 1),
+          width: 1.5,
+        ),
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      margin: const EdgeInsets.all(outerInset),
+      child: Container(
+        decoration: booking.isLocked
+            ? BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                gradient: const LinearGradient(
+                  begin: AlignmentDirectional.topStart,
+                  end: Alignment(-0.4, -0.2),
+                  colors: [
+                    Color.fromARGB(16, 0, 0, 0),
+                    Color.fromARGB(16, 0, 0, 0),
+                    Colors.white10,
+                    Colors.white10,
+                  ],
+                  stops: [0, 0.5, 0.5, 1],
+                  tileMode: TileMode.repeated,
+                ),
+              )
+            : BoxDecoration(
+                color: Theme.of(context)
+                    .cardColor
+                    .withOpacity(isBeforeNow ? 0.41 : 1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+        width: width,
+        height: height,
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR detaches the `BookingCard`’s interactive layer into a different Widget, allowing different composition needs (e.g., facilitating the work needed for #188).