### PR TITLE
fix(booking_preview_panel_overlay): resolve offset from correct context

### DIFF
--- a/lib/widgets/booking/booking_preview_panel_overlay.dart
+++ b/lib/widgets/booking/booking_preview_panel_overlay.dart
@@ -64,13 +64,14 @@ class _BookingPreviewPanelOverlayState
     _lastBookingId = booking.id;
     setPreventTimeTableScroll?.call(value: true);
 
+    final resolvedOffset = _resolvedOffsetFromContext(context, renderBox);
     _overlayEntry = OverlayEntry(
       builder: (context) {
         return _PreviewPanel(
           cabin: cabin,
           booking: booking,
           width: widget.width,
-          offset: _resolvedOffsetFromContext(context, renderBox),
+          offset: resolvedOffset,
           layerLink: _layerLink,
           renderBox: renderBox,
           onWillPop: () => _hidePreviewPanel(


### PR DESCRIPTION
Addresses an issue introduced in #187, where the `BuildContext` used to resolve the preview panel offset was changed to the `OverlayEntry` builder’s context, preventing from finding the correct `RenderObject`. Instead, the `BookingPreviewPanelOverlay` context is used again.