### PR TITLE
refactor(utils): move `formatRelative` methods to `AppLocalizationsExtension`

### DIFF
--- a/lib/utils/app_localizations_extension.dart
+++ b/lib/utils/app_localizations_extension.dart
@@ -1,4 +1,8 @@
+// ignore: format-comment
+// coverage:ignore-file
+import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
 
 extension AppLocalizationsExtension on AppLocalizations {
   // Cabin.
@@ -23,4 +27,29 @@ extension AppLocalizationsExtension on AppLocalizations {
         ...monthlyPeriodicity,
         ...annuallyPeriodicity,
       ];
+
+  String _formatRelativeDate(DateTime dateTime) {
+    if (dateTime.isToday) return today;
+    if (dateTime.isYesterday) return yesterday;
+    if (dateTime.isTomorrow) return tomorrow;
+
+    return DateFormat.yMMMEd().format(dateTime);
+  }
+
+  /// Returns a relatively formatted [String] from the given [DateTime].
+  ///
+  /// Example:
+  /// ```dart
+  /// final today = DateTime.now();
+  /// assert(appLocalizations.formatRelative(today) == 'Today, 09:00');
+  ///
+  /// final yesterday = today.subtract(const Duration(days: 1));
+  /// assert(appLocalizations.formatRelative(yesterday) == 'Yesterday, 09:00');
+  /// ```
+  String formatRelative(DateTime dateTime) {
+    final date = _formatRelativeDate(dateTime);
+    final time = DateFormat.Hm().format(dateTime);
+
+    return [date, time].join(', ');
+  }
 }

--- a/lib/utils/date_time_extension.dart
+++ b/lib/utils/date_time_extension.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:intl/intl.dart';
 
 /// DateTime extension.
 extension DateTimeExtension on DateTime {
@@ -77,31 +75,4 @@ extension DateTimeExtension on DateTime {
   /// Whether this [DateTime] refers to the same date as tomorrow.
   bool get isTomorrow =>
       isSameDateAs(DateTime.now().add(const Duration(days: 1)));
-
-  String _formatRelativeDate(AppLocalizations appLocalizations) {
-    if (isToday) return appLocalizations.today;
-    if (isYesterday) return appLocalizations.yesterday;
-    if (isTomorrow) return appLocalizations.tomorrow;
-
-    return DateFormat.yMMMEd().format(this);
-  }
-
-  String _formatRelativeTime() => DateFormat.Hm().format(this);
-
-  /// Returns a relatively formatted [String] from this [DateTime].
-  ///
-  /// Example:
-  /// ```dart
-  /// final today = DateTime.now();
-  /// assert(today.formatRelative(appLocalizations) == 'Today, 09:00');
-  ///
-  /// final yesterday = today.subtract(const Duration(days: 1));
-  /// assert(yesterday.formatRelative(appLocalizations) == 'Yesterday, 09:00');
-  /// ```
-  String formatRelative(AppLocalizations appLocalizations) {
-    final date = _formatRelativeDate(appLocalizations);
-    final time = _formatRelativeTime();
-
-    return [date, time].join(', ');
-  }
 }

--- a/lib/widgets/jump_bar/booking_search_result.dart
+++ b/lib/widgets/jump_bar/booking_search_result.dart
@@ -1,5 +1,5 @@
 import 'package:cabin_booking/model.dart';
-import 'package:cabin_booking/utils/date_time_extension.dart';
+import 'package:cabin_booking/utils/app_localizations_extension.dart';
 import 'package:cabin_booking/widgets/jump_bar/search_result_label.dart';
 import 'package:collection/collection.dart' show IterableNullableExtension;
 import 'package:flutter/material.dart';
@@ -41,8 +41,9 @@ class BookingSearchResult extends StatelessWidget {
                     )
                   : null,
               formatter: (dateRange) {
-                final startDate =
-                    dateRange.startDate?.formatRelative(appLocalizations);
+                final startDate = dateRange.startDate == null
+                    ? null
+                    : appLocalizations.formatRelative(dateRange.startDate!);
 
                 final endDate = dateRange.endDate != null
                     ? DateFormat.Hm().format(dateRange.endDate!)


### PR DESCRIPTION
As `formatRelative` methods depend on `AppLocalizations`, this PR moves them to `AppLocalizationsExtension` to keep all dependant methods and getters in the same place.

Additionally, the `app_localizations_extension.dart` file has been ignored from coverage, as there’s no straightforward way of testing its whole set of getters and methods.