### PR TITLE
refactor: use appropriate variable names for `DateRanger`

### DIFF
--- a/lib/src/model/booking_collection.dart
+++ b/lib/src/model/booking_collection.dart
@@ -58,22 +58,22 @@ class BookingCollection with ChangeNotifier implements Serializable {
         ...singleBookingsFromRecurring,
       });
 
-  Set<SingleBooking> singleBookingsBetween(DateRanger dateRange) =>
+  Set<SingleBooking> singleBookingsBetween(DateRanger dateRanger) =>
       SplayTreeSet.of(
-        bookings.where((booking) => booking.overlapsWith(dateRange)),
+        bookings.where((booking) => booking.overlapsWith(dateRanger)),
       );
 
-  Set<SingleBooking> recurringBookingsBetween(DateRanger dateRange) =>
+  Set<SingleBooking> recurringBookingsBetween(DateRanger dateRanger) =>
       SplayTreeSet.of(
         singleBookingsFromRecurring.where(
-          (recurringBooking) => recurringBooking.overlapsWith(dateRange),
+          (recurringBooking) => recurringBooking.overlapsWith(dateRanger),
         ),
       );
 
-  Set<SingleBooking> allBookingsBetween(DateRanger dateRange) =>
+  Set<SingleBooking> allBookingsBetween(DateRanger dateRanger) =>
       SplayTreeSet.of({
-        ...singleBookingsBetween(dateRange),
-        ...recurringBookingsBetween(dateRange),
+        ...singleBookingsBetween(dateRanger),
+        ...recurringBookingsBetween(dateRanger),
       });
 
   Set<SingleBooking> singleBookingsOn(DateTime dateTime) => SplayTreeSet.of(
@@ -82,7 +82,6 @@ class BookingCollection with ChangeNotifier implements Serializable {
 
   Set<SingleBooking> recurringBookingsOn(DateTime dateTime) {
     final filteredBookings = SplayTreeSet<SingleBooking>();
-
     for (final recurringBooking in recurringBookings) {
       final booking = recurringBooking.bookingOn(dateTime);
 
@@ -174,11 +173,10 @@ class BookingCollection with ChangeNotifier implements Serializable {
     return runPercent;
   }
 
-  Set<DateTime> datesWithBookings([DateRanger? dateRange]) {
+  Set<DateTime> datesWithBookings([DateRanger? dateRanger]) {
     final dates = SplayTreeSet<DateTime>();
-
     final bookingsList =
-        dateRange != null ? allBookingsBetween(dateRange) : allBookings;
+        dateRanger != null ? allBookingsBetween(dateRanger) : allBookings;
 
     for (final booking in bookingsList) {
       final shouldAddDate = dates.firstWhereOrNull(
@@ -196,7 +194,6 @@ class BookingCollection with ChangeNotifier implements Serializable {
 
   Map<DateTime, int> get allBookingsCountPerDay {
     final bookingsPerDay = SplayTreeMap<DateTime, int>();
-
     for (final booking in allBookings) {
       bookingsPerDay.update(
         booking.dateOnly!,
@@ -208,11 +205,12 @@ class BookingCollection with ChangeNotifier implements Serializable {
     return bookingsPerDay;
   }
 
-  Map<DateTime, Duration> occupiedDurationPerWeek([DateRanger? dateRange]) {
+  Map<DateTime, Duration> occupiedDurationPerWeek([DateRanger? dateRanger]) {
     final bookingsPerDay = SplayTreeMap<DateTime, Duration>();
-
     for (final booking in allBookings) {
-      if (dateRange != null && !dateRange.includes(booking.dateOnly!)) continue;
+      if (dateRanger != null && !dateRanger.includes(booking.dateOnly!)) {
+        continue;
+      }
 
       bookingsPerDay.update(
         booking.dateOnly!.firstDayOfWeek,
@@ -225,14 +223,13 @@ class BookingCollection with ChangeNotifier implements Serializable {
   }
 
   Map<TimeOfDay, Duration> accumulatedTimeRangesOccupancy([
-    DateRanger? dateRange,
+    DateRanger? dateRanger,
   ]) {
     final timeRanges =
         SplayTreeMap<TimeOfDay, Duration>(TimeOfDayExtension.compare);
 
     final bookingsSet =
-        dateRange != null ? allBookingsBetween(dateRange) : allBookings;
-
+        dateRanger != null ? allBookingsBetween(dateRanger) : allBookings;
     for (final booking in bookingsSet) {
       for (final bookingTimeRange in booking.hoursSpan.entries) {
         timeRanges.update(
@@ -256,7 +253,6 @@ class BookingCollection with ChangeNotifier implements Serializable {
       accumulatedTimeRangesOccupancy.entries,
       (a, b) => a.value.compareTo(b.value),
     );
-
     final highestOccupancyDuration = timeRangesSortedByDuration.first.value;
 
     return SplayTreeSet.of(
@@ -267,9 +263,9 @@ class BookingCollection with ChangeNotifier implements Serializable {
     );
   }
 
-  Set<TimeOfDay> mostOccupiedTimeRange([DateRanger? dateRange]) =>
+  Set<TimeOfDay> mostOccupiedTimeRange([DateRanger? dateRanger]) =>
       mostOccupiedTimeRangeFromAccumulated(
-        accumulatedTimeRangesOccupancy(dateRange),
+        accumulatedTimeRangesOccupancy(dateRanger),
       );
 
   SingleBooking singleBookingFromId(String id) =>

--- a/lib/src/model/cabin_collection.dart
+++ b/lib/src/model/cabin_collection.dart
@@ -42,15 +42,14 @@ class CabinCollection extends WritableManager<Set<Cabin>>
 
   int get lastCabinNumber => cabins.isEmpty ? 0 : cabins.last.number;
 
-  Set<DateTime> allCabinsDatesWithBookings([DateRanger? dateRange]) =>
+  Set<DateTime> allCabinsDatesWithBookings([DateRanger? dateRanger]) =>
       SplayTreeSet.of({
         for (final cabin in cabins)
-          ...cabin.bookingCollection.datesWithBookings(dateRange),
+          ...cabin.bookingCollection.datesWithBookings(dateRanger),
       });
 
   Map<DateTime, int> get allCabinsBookingsCountPerDay {
     final bookingsPerDay = <DateTime, int>{};
-
     for (final cabin in cabins) {
       for (final bookingsCount
           in cabin.bookingCollection.allBookingsCountPerDay.entries) {
@@ -75,15 +74,13 @@ class CabinCollection extends WritableManager<Set<Cabin>>
   }
 
   Map<TimeOfDay, Duration> accumulatedTimeRangesOccupancy([
-    DateRanger? dateRange,
+    DateRanger? dateRanger,
   ]) {
     final timeRanges =
         SplayTreeMap<TimeOfDay, Duration>(TimeOfDayExtension.compare);
-
     for (final cabin in cabins) {
       final accumulatedTimeRanges =
-          cabin.bookingCollection.accumulatedTimeRangesOccupancy(dateRange);
-
+          cabin.bookingCollection.accumulatedTimeRangesOccupancy(dateRanger);
       for (final bookingTimeRange in accumulatedTimeRanges.entries) {
         timeRanges.update(
           bookingTimeRange.key,
@@ -96,14 +93,13 @@ class CabinCollection extends WritableManager<Set<Cabin>>
     return timeRanges;
   }
 
-  Set<TimeOfDay> mostOccupiedTimeRange([DateRanger? dateRange]) =>
+  Set<TimeOfDay> mostOccupiedTimeRange([DateRanger? dateRanger]) =>
       BookingCollection.mostOccupiedTimeRangeFromAccumulated(
-        accumulatedTimeRangesOccupancy(dateRange),
+        accumulatedTimeRangesOccupancy(dateRanger),
       );
 
   int get allBookingsCount {
     var count = 0;
-
     for (final cabin in cabins) {
       count += cabin.bookingCollection.allBookings.length;
     }
@@ -113,7 +109,6 @@ class CabinCollection extends WritableManager<Set<Cabin>>
 
   int get bookingsCount {
     var count = 0;
-
     for (final cabin in cabins) {
       count += cabin.bookingCollection.bookings.length;
     }
@@ -123,7 +118,6 @@ class CabinCollection extends WritableManager<Set<Cabin>>
 
   int get recurringBookingsCount {
     var count = 0;
-
     for (final cabin in cabins) {
       count += cabin.bookingCollection.singleBookingsFromRecurring.length;
     }
@@ -144,13 +138,11 @@ class CabinCollection extends WritableManager<Set<Cabin>>
     return duration;
   }
 
-  Map<DateTime, Duration> occupiedDurationPerWeek([DateRanger? dateRange]) {
+  Map<DateTime, Duration> occupiedDurationPerWeek([DateRanger? dateRanger]) {
     final bookingsPerDay = SplayTreeMap<DateTime, Duration>();
-
     for (final cabin in cabins) {
       final occupiedDuration =
-          cabin.bookingCollection.occupiedDurationPerWeek(dateRange);
-
+          cabin.bookingCollection.occupiedDurationPerWeek(dateRanger);
       for (final durationPerWeek in occupiedDuration.entries) {
         bookingsPerDay.update(
           durationPerWeek.key,
@@ -183,22 +175,20 @@ class CabinCollection extends WritableManager<Set<Cabin>>
         percents.length;
   }
 
-  int bookingsCountBetween(DateRanger dateRange) {
+  int bookingsCountBetween(DateRanger dateRanger) {
     var count = 0;
-
     for (final cabin in cabins) {
-      count += cabin.bookingCollection.singleBookingsBetween(dateRange).length;
+      count += cabin.bookingCollection.singleBookingsBetween(dateRanger).length;
     }
 
     return count;
   }
 
-  int recurringBookingsCountBetween(DateRanger dateRange) {
+  int recurringBookingsCountBetween(DateRanger dateRanger) {
     var count = 0;
-
     for (final cabin in cabins) {
       count +=
-          cabin.bookingCollection.recurringBookingsBetween(dateRange).length;
+          cabin.bookingCollection.recurringBookingsBetween(dateRanger).length;
     }
 
     return count;

--- a/lib/widgets/item/activity_line_chart.dart
+++ b/lib/widgets/item/activity_line_chart.dart
@@ -7,13 +7,13 @@ import 'package:flutter/material.dart';
 
 class ActivityLineChart extends StatelessWidget {
   final Map<DateTime, Duration> occupiedDurationPerWeek;
-  final DateRanger dateRange;
+  final DateRanger dateRanger;
   final String? tooltipMessage;
 
   const ActivityLineChart({
     super.key,
     this.occupiedDurationPerWeek = const {},
-    required this.dateRange,
+    required this.dateRanger,
     this.tooltipMessage,
   });
 
@@ -35,8 +35,8 @@ class ActivityLineChart extends StatelessWidget {
             for (final entry in occupiedDurationPerWeek.entries)
               FlSpot(entry.key.toDouble(), entry.value.inMinutes.toDouble()),
           ],
-          minX: dateRange.startDate?.toDouble(),
-          maxX: dateRange.endDate?.toDouble(),
+          minX: dateRanger.startDate?.toDouble(),
+          maxX: dateRanger.endDate?.toDouble(),
         ),
       ),
     );

--- a/lib/widgets/item/items_table.dart
+++ b/lib/widgets/item/items_table.dart
@@ -239,7 +239,7 @@ class _ItemsTableState<T extends Item> extends State<ItemsTable<T>> {
                       DataCell(
                         ActivityLineChart(
                           occupiedDurationPerWeek: row.occupiedDurationPerWeek,
-                          dateRange: row.item is DateRanger
+                          dateRanger: row.item is DateRanger
                               ? row.item as DateRanger
                               : DateRange(
                                   startDate: DateTime.now()

--- a/test/model/date/date_range_item_test.dart
+++ b/test/model/date/date_range_item_test.dart
@@ -46,13 +46,16 @@ void main() {
 
     group('.copyWith()', () {
       test('should create a copy of this DateRangeItem', () {
-        final dateRange = DateRangeItem(
+        final dateRangeItem = DateRangeItem(
           startDate: DateTime.utc(2022, 9, 11),
           endDate: DateTime.utc(2023, 6, 23),
         );
-        expect(dateRange, dateRange.copyWith());
-        expect(identical(dateRange, dateRange.copyWith()), isFalse);
-        expect(identical(dateRange.copyWith(), dateRange.copyWith()), isFalse);
+        expect(dateRangeItem, dateRangeItem.copyWith());
+        expect(identical(dateRangeItem, dateRangeItem.copyWith()), isFalse);
+        expect(
+          identical(dateRangeItem.copyWith(), dateRangeItem.copyWith()),
+          isFalse,
+        );
       });
 
       test(
@@ -60,13 +63,13 @@ void main() {
         () {
           final startDate = DateTime(2022, 12, 4);
           final endDate = DateTime(2022, 12, 5);
-          final dateRange = DateRangeItem(
+          final dateRangeItem = DateRangeItem(
             id: 'date-range-item-id',
             startDate: startDate,
             endDate: endDate,
           );
           expect(
-            dateRange,
+            dateRangeItem,
             DateRangeItem(
               id: 'date-range-item-id',
               startDate: DateTime.utc(2022, 9, 11),

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -326,21 +326,21 @@ void main() {
 
     group('.duration', () {
       test('should return the Duration of a finite DateRanger', () {
-        final DateRanger hourDateRange = DateRange(
+        final DateRanger hourDateRanger = DateRange(
           startDate: DateTime(2022, 12, 4, 9, 15),
           endDate: DateTime(2022, 12, 4, 10, 15),
         );
-        expect(hourDateRange.duration, const Duration(hours: 1));
+        expect(hourDateRanger.duration, const Duration(hours: 1));
 
-        final DateRanger dayDateRange =
+        final DateRanger dayDateRanger =
             DateRange.fromDate(DateTime(2022, 12, 4));
-        expect(dayDateRange.duration, const Duration(days: 1));
+        expect(dayDateRanger.duration, const Duration(days: 1));
 
-        final DateRanger weekDateRange = DateRange(
+        final DateRanger weekDateRanger = DateRange(
           startDate: DateTime(2022, 12, 27),
           endDate: DateTime(2023, 1, 3),
         );
-        expect(weekDateRange.duration, const Duration(days: 7));
+        expect(weekDateRanger.duration, const Duration(days: 7));
       });
 
       test('should return a Duration of zero for an infinite DateRanger', () {
@@ -497,11 +497,11 @@ void main() {
         );
         expect(dateRanger.textualTime, '09:30–21:30');
 
-        final DateRanger multiYearDateRange = DateRange(
+        final DateRanger multiYearDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2023, 1, 12, 21, 30),
         );
-        expect(multiYearDateRange.textualTime, '09:30–21:30');
+        expect(multiYearDateRanger.textualTime, '09:30–21:30');
       });
 
       test(
@@ -530,10 +530,10 @@ void main() {
           );
           expect(dateRanger.textualTime, '09:30 – null');
 
-          final DateRanger multiYearDateRange = DateRange(
+          final DateRanger multiYearDateRanger = DateRange(
             endDate: DateTime(2023, 1, 12, 21, 30),
           );
-          expect(multiYearDateRange.textualTime, 'null – 21:30');
+          expect(multiYearDateRanger.textualTime, 'null – 21:30');
 
           expect(DateRange.infinite.textualTime, 'null – null');
         },
@@ -557,9 +557,9 @@ void main() {
 
       test('should return an empty Map for an instant DateRanger', () {
         final dateTime = DateTime(2022, 12, 4);
-        final DateRanger instantDateRange =
+        final DateRanger instantDateRanger =
             DateRange(startDate: dateTime, endDate: dateTime);
-        expect(instantDateRange.hoursSpan, const <TimeOfDay, Duration>{});
+        expect(instantDateRanger.hoursSpan, const <TimeOfDay, Duration>{});
       });
 
       test('should return an empty Map for an infinite DateRanger', () {

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('DateRanger', () {
     group('.startTime', () {
       test('should return the start TimeOfDay', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
@@ -14,17 +14,17 @@ void main() {
       });
 
       test('should return null if the start date is infinite', () {
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.startTime, isNull);
+        expect(endDateRanger.startTime, isNull);
         expect(DateRange.infinite.startTime, isNull);
       });
     });
 
     group('.endTime', () {
       test('should return the end TimeOfDay', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
@@ -32,10 +32,10 @@ void main() {
       });
 
       test('should return null if the end date is infinite', () {
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 31, 9, 30),
         );
-        expect(startDateRange.endTime, isNull);
+        expect(startDateRanger.endTime, isNull);
         expect(DateRange.infinite.endTime, isNull);
       });
     });
@@ -45,7 +45,7 @@ void main() {
         'should return true if this finite DateRanger happens on a DateTime',
         () {
           final dateTime = DateTime(2022, 12, 4);
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 4, 9, 45),
             endDate: DateTime(2022, 12, 5, 21, 15),
           );
@@ -57,12 +57,12 @@ void main() {
         'should return true if this infinite DateRanger happens on a DateTime',
         () {
           final dateTime = DateTime(2022, 12, 4);
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             endDate: DateTime(2022, 12, 5, 21, 15),
           );
           expect(dateRanger.isOn(dateTime), isTrue);
 
-          final dateRanger2 = DateRange(
+          final DateRanger dateRanger2 = DateRange(
             startDate: DateTime(2022, 12, 3, 9, 45),
           );
           expect(dateRanger2.isOn(dateTime), isTrue);
@@ -76,7 +76,7 @@ void main() {
         'DateTime',
         () {
           final dateTime = DateTime(2022, 12, 3);
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 4, 9, 45),
             endDate: DateTime(2022, 12, 5, 21, 15),
           );
@@ -90,12 +90,12 @@ void main() {
         () {
           final dateTime = DateTime(2022, 12, 4);
 
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 5, 21, 15),
           );
           expect(dateRanger.isOn(dateTime), isFalse);
 
-          final dateRanger2 = DateRange(
+          final DateRanger dateRanger2 = DateRange(
             endDate: DateTime(2022, 12, 3, 9, 45),
           );
           expect(dateRanger2.isOn(dateTime), isFalse);
@@ -109,7 +109,7 @@ void main() {
         () {
           final startDateTime = DateTime(2022, 12, 1, 9, 30);
           final endDateTime = DateTime(2022, 12, 31, 21, 30);
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: startDateTime,
             endDate: endDateTime,
           );
@@ -118,11 +118,12 @@ void main() {
           final dateTime = DateTime(2022, 12, 4, 11, 30);
           expect(dateRanger.includes(dateTime), isTrue);
 
-          final startDateRange = DateRange(startDate: startDateTime);
-          expect(startDateRange.includes(dateTime), isTrue);
+          final DateRanger startDateRanger =
+              DateRange(startDate: startDateTime);
+          expect(startDateRanger.includes(dateTime), isTrue);
 
-          final endDateRange = DateRange(endDate: endDateTime);
-          expect(endDateRange.includes(dateTime), isTrue);
+          final DateRanger endDateRanger = DateRange(endDate: endDateTime);
+          expect(endDateRanger.includes(dateTime), isTrue);
         },
       );
 
@@ -132,22 +133,22 @@ void main() {
         () {
           final beforeDateTime = DateTime(2022, 12, 1, 8);
           final afterDateTime = DateTime(2022, 12, 31, 21, 45);
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2022, 12, 31, 21, 30),
           );
           expect(dateRanger.includes(beforeDateTime), isFalse);
           expect(dateRanger.includes(afterDateTime), isFalse);
 
-          final startDateRange = DateRange(
+          final DateRanger startDateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
           );
-          expect(startDateRange.includes(afterDateTime), isTrue);
+          expect(startDateRanger.includes(afterDateTime), isTrue);
 
-          final endDateRange = DateRange(
+          final DateRanger endDateRanger = DateRange(
             endDate: DateTime(2022, 12, 31, 21, 30),
           );
-          expect(endDateRange.includes(beforeDateTime), isTrue);
+          expect(endDateRanger.includes(beforeDateTime), isTrue);
         },
       );
 
@@ -162,11 +163,11 @@ void main() {
         'should return true if this finite DateRanger overlaps with another '
         'finite DateRanger',
         () {
-          final dateRanger1 = DateRange(
+          final DateRanger dateRanger1 = DateRange(
             startDate: DateTime(2022, 12, 4, 9, 15),
             endDate: DateTime(2022, 12, 4, 12, 15),
           );
-          final dateRanger2 = DateRange(
+          final DateRanger dateRanger2 = DateRange(
             startDate: DateTime(2022, 12, 4, 10, 15),
             endDate: DateTime(2022, 12, 4, 11, 15),
           );
@@ -179,10 +180,10 @@ void main() {
         'should return true if this infinite DateRanger overlaps with another '
         'infinite DateRanger',
         () {
-          final dateRanger1 = DateRange(
+          final DateRanger dateRanger1 = DateRange(
             endDate: DateTime(2022, 12, 4, 12, 15),
           );
-          final dateRanger2 = DateRange(
+          final DateRanger dateRanger2 = DateRange(
             startDate: DateTime(2022, 12, 4, 10, 15),
           );
           expect(dateRanger1.overlapsWith(dateRanger2), isTrue);
@@ -191,7 +192,8 @@ void main() {
           expect(DateRange.infinite.overlapsWith(DateRange.infinite), isTrue);
           expect(DateRange.infinite.overlapsWith(dateRanger1), isTrue);
           expect(dateRanger1.overlapsWith(DateRange.infinite), isTrue);
-          final dateRanger3 = DateRange.fromDate(DateTime(2022, 12, 4));
+          final DateRanger dateRanger3 =
+              DateRange.fromDate(DateTime(2022, 12, 4));
           expect(DateRange.infinite.overlapsWith(dateRanger3), isTrue);
           expect(dateRanger3.overlapsWith(DateRange.infinite), isTrue);
         },
@@ -201,8 +203,10 @@ void main() {
         'should return false if this finite DateRanger does not overlap with '
         'another finite DateRanger',
         () {
-          final dateRanger1 = DateRange.fromDate(DateTime(2022, 12, 4));
-          final dateRanger2 = DateRange.fromDate(DateTime(2022, 12, 5));
+          final DateRanger dateRanger1 =
+              DateRange.fromDate(DateTime(2022, 12, 4));
+          final DateRanger dateRanger2 =
+              DateRange.fromDate(DateTime(2022, 12, 5));
           expect(dateRanger1.overlapsWith(dateRanger2), isFalse);
           expect(dateRanger2.overlapsWith(dateRanger1), isFalse);
         },
@@ -212,10 +216,10 @@ void main() {
         'should return false if this infinite DateRanger does not overlap with '
         'another infinite DateRanger',
         () {
-          final dateRanger1 = DateRange(
+          final DateRanger dateRanger1 = DateRange(
             startDate: DateTime(2022, 12, 4, 12, 15),
           );
-          final dateRanger2 = DateRange(
+          final DateRanger dateRanger2 = DateRange(
             endDate: DateTime(2022, 12, 4, 10, 15),
           );
           expect(dateRanger1.overlapsWith(dateRanger2), isFalse);
@@ -226,7 +230,7 @@ void main() {
 
     group('.isFinite', () {
       test('should return true when this DateRanger is finite', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
@@ -234,15 +238,15 @@ void main() {
       });
 
       test('should return false when this DateRanger is infinite', () {
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
         );
-        expect(startDateRange.isFinite, isFalse);
+        expect(startDateRanger.isFinite, isFalse);
 
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.isFinite, isFalse);
+        expect(endDateRanger.isFinite, isFalse);
 
         expect(DateRange.infinite.isFinite, isFalse);
       });
@@ -250,21 +254,21 @@ void main() {
 
     group('.isInfinite', () {
       test('should return true when this DateRanger is infinite', () {
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
         );
-        expect(startDateRange.isInfinite, isTrue);
+        expect(startDateRanger.isInfinite, isTrue);
 
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.isInfinite, isTrue);
+        expect(endDateRanger.isInfinite, isTrue);
 
         expect(DateRange.infinite.isInfinite, isTrue);
       });
 
       test('should return false when this DateRanger is finite', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
@@ -274,64 +278,65 @@ void main() {
 
     group('.hasInfiniteStart', () {
       test('should return true when this DateRanger has an infinite start', () {
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.hasInfiniteStart, isTrue);
+        expect(endDateRanger.hasInfiniteStart, isTrue);
 
         expect(DateRange.infinite.hasInfiniteStart, isTrue);
       });
 
       test('should return false when this DateRanger has a finite start', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
         expect(dateRanger.hasInfiniteStart, isFalse);
 
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
         );
-        expect(startDateRange.hasInfiniteStart, isFalse);
+        expect(startDateRanger.hasInfiniteStart, isFalse);
       });
     });
 
     group('.hasInfiniteEnd', () {
       test('should return true when this DateRanger has an infinite end', () {
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
         );
-        expect(startDateRange.hasInfiniteEnd, isTrue);
+        expect(startDateRanger.hasInfiniteEnd, isTrue);
 
         expect(DateRange.infinite.hasInfiniteEnd, isTrue);
       });
 
       test('should return false when this DateRanger has a finite end', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
         expect(dateRanger.hasInfiniteEnd, isFalse);
 
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.hasInfiniteEnd, isFalse);
+        expect(endDateRanger.hasInfiniteEnd, isFalse);
       });
     });
 
     group('.duration', () {
       test('should return the Duration of a finite DateRanger', () {
-        final hourDateRange = DateRange(
+        final DateRanger hourDateRange = DateRange(
           startDate: DateTime(2022, 12, 4, 9, 15),
           endDate: DateTime(2022, 12, 4, 10, 15),
         );
         expect(hourDateRange.duration, const Duration(hours: 1));
 
-        final dayDateRange = DateRange.fromDate(DateTime(2022, 12, 4));
+        final DateRanger dayDateRange =
+            DateRange.fromDate(DateTime(2022, 12, 4));
         expect(dayDateRange.duration, const Duration(days: 1));
 
-        final weekDateRange = DateRange(
+        final DateRanger weekDateRange = DateRange(
           startDate: DateTime(2022, 12, 27),
           endDate: DateTime(2023, 1, 3),
         );
@@ -339,15 +344,15 @@ void main() {
       });
 
       test('should return a Duration of zero for an infinite DateRanger', () {
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
         );
-        expect(startDateRange.duration, Duration.zero);
+        expect(startDateRanger.duration, Duration.zero);
 
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.duration, Duration.zero);
+        expect(endDateRanger.duration, Duration.zero);
 
         expect(DateRange.infinite.duration, Duration.zero);
       });
@@ -358,7 +363,7 @@ void main() {
         'should return a textual range representation of a finite '
         'DateRanger with the same year',
         () {
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2022, 12, 31, 21, 30),
           );
@@ -390,7 +395,7 @@ void main() {
         'should return a textual range representation of a finite '
         'DateRanger with the same year and day',
         () {
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2022, 12, 1, 21, 30),
           );
@@ -435,7 +440,7 @@ void main() {
         'should return a textual range representation of a finite '
         'DateRanger with different years',
         () {
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2023, 1, 12, 21, 30),
           );
@@ -463,19 +468,19 @@ void main() {
         'should return a textual range representation of an infinite '
         'DateRanger',
         () {
-          final startDateRange = DateRange(
+          final DateRanger startDateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
           );
           expect(
-            startDateRange.textualDateTime(),
+            startDateRanger.textualDateTime(),
             'December 1, 2022 09:30 – null',
           );
 
-          final endDateRange = DateRange(
+          final DateRanger endDateRanger = DateRange(
             endDate: DateTime(2022, 12, 31, 21, 30),
           );
           expect(
-            endDateRange.textualDateTime(),
+            endDateRanger.textualDateTime(),
             'null – December 31, 2022 21:30',
           );
 
@@ -486,13 +491,13 @@ void main() {
 
     group('.textualTime', () {
       test('should return the textual time range of a finite DateRanger', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 1, 21, 30),
         );
         expect(dateRanger.textualTime, '09:30–21:30');
 
-        final multiYearDateRange = DateRange(
+        final DateRanger multiYearDateRange = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2023, 1, 12, 21, 30),
         );
@@ -502,7 +507,7 @@ void main() {
       test(
         'should return the textual local time range of a UTC DateRanger',
         () {
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime.utc(2022, 12, 1, 9, 30),
             endDate: DateTime.utc(2022, 12, 1, 21, 45),
           );
@@ -520,12 +525,12 @@ void main() {
       test(
         'should return the textual time range of an infinite DateRanger',
         () {
-          final dateRanger = DateRange(
+          final DateRanger dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
           );
           expect(dateRanger.textualTime, '09:30 – null');
 
-          final multiYearDateRange = DateRange(
+          final DateRanger multiYearDateRange = DateRange(
             endDate: DateTime(2023, 1, 12, 21, 30),
           );
           expect(multiYearDateRange.textualTime, 'null – 21:30');
@@ -537,7 +542,7 @@ void main() {
 
     group('.hoursSpan', () {
       test('should return a Map of the time span of this DateRanger', () {
-        final dateRanger = DateRange(
+        final DateRanger dateRanger = DateRange(
           startDate: DateTime(2022, 12, 4, 9, 30),
           endDate: DateTime(2022, 12, 4, 13, 15),
         );
@@ -552,21 +557,21 @@ void main() {
 
       test('should return an empty Map for an instant DateRanger', () {
         final dateTime = DateTime(2022, 12, 4);
-        final instantDateRange =
+        final DateRanger instantDateRange =
             DateRange(startDate: dateTime, endDate: dateTime);
         expect(instantDateRange.hoursSpan, const <TimeOfDay, Duration>{});
       });
 
       test('should return an empty Map for an infinite DateRanger', () {
-        final startDateRange = DateRange(
+        final DateRanger startDateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
         );
-        expect(startDateRange.hoursSpan, const <TimeOfDay, Duration>{});
+        expect(startDateRanger.hoursSpan, const <TimeOfDay, Duration>{});
 
-        final endDateRange = DateRange(
+        final DateRanger endDateRanger = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(endDateRange.hoursSpan, const <TimeOfDay, Duration>{});
+        expect(endDateRanger.hoursSpan, const <TimeOfDay, Duration>{});
 
         expect(DateRange.infinite.hoursSpan, const <TimeOfDay, Duration>{});
       });
@@ -574,7 +579,7 @@ void main() {
 
     group('.dateTimeList()', () {
       test('should return a DateTime list included in this DateRanger', () {
-        final dateRanger = DateRange.fromDate(DateTime(2022, 12, 4));
+        final DateRanger dateRanger = DateRange.fromDate(DateTime(2022, 12, 4));
         expect(dateRanger.dateTimeList(interval: const Duration(hours: 8)), [
           DateTime(2022, 12, 4),
           DateTime(2022, 12, 4, 8),

--- a/test/model/date/date_ranger_test.dart
+++ b/test/model/date/date_ranger_test.dart
@@ -6,11 +6,11 @@ void main() {
   group('DateRanger', () {
     group('.startTime', () {
       test('should return the start TimeOfDay', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(dateRange.startTime, const TimeOfDay(hour: 9, minute: 30));
+        expect(dateRanger.startTime, const TimeOfDay(hour: 9, minute: 30));
       });
 
       test('should return null if the start date is infinite', () {
@@ -24,11 +24,11 @@ void main() {
 
     group('.endTime', () {
       test('should return the end TimeOfDay', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(dateRange.endTime, const TimeOfDay(hour: 21, minute: 30));
+        expect(dateRanger.endTime, const TimeOfDay(hour: 21, minute: 30));
       });
 
       test('should return null if the end date is infinite', () {
@@ -45,11 +45,11 @@ void main() {
         'should return true if this finite DateRanger happens on a DateTime',
         () {
           final dateTime = DateTime(2022, 12, 4);
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 4, 9, 45),
             endDate: DateTime(2022, 12, 5, 21, 15),
           );
-          expect(dateRange.isOn(dateTime), isTrue);
+          expect(dateRanger.isOn(dateTime), isTrue);
         },
       );
 
@@ -57,15 +57,15 @@ void main() {
         'should return true if this infinite DateRanger happens on a DateTime',
         () {
           final dateTime = DateTime(2022, 12, 4);
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             endDate: DateTime(2022, 12, 5, 21, 15),
           );
-          expect(dateRange.isOn(dateTime), isTrue);
+          expect(dateRanger.isOn(dateTime), isTrue);
 
-          final dateRange2 = DateRange(
+          final dateRanger2 = DateRange(
             startDate: DateTime(2022, 12, 3, 9, 45),
           );
-          expect(dateRange2.isOn(dateTime), isTrue);
+          expect(dateRanger2.isOn(dateTime), isTrue);
 
           expect(DateRange.infinite.isOn(dateTime), isTrue);
         },
@@ -76,11 +76,11 @@ void main() {
         'DateTime',
         () {
           final dateTime = DateTime(2022, 12, 3);
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 4, 9, 45),
             endDate: DateTime(2022, 12, 5, 21, 15),
           );
-          expect(dateRange.isOn(dateTime), isFalse);
+          expect(dateRanger.isOn(dateTime), isFalse);
         },
       );
 
@@ -90,15 +90,15 @@ void main() {
         () {
           final dateTime = DateTime(2022, 12, 4);
 
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 5, 21, 15),
           );
-          expect(dateRange.isOn(dateTime), isFalse);
+          expect(dateRanger.isOn(dateTime), isFalse);
 
-          final dateRange2 = DateRange(
+          final dateRanger2 = DateRange(
             endDate: DateTime(2022, 12, 3, 9, 45),
           );
-          expect(dateRange2.isOn(dateTime), isFalse);
+          expect(dateRanger2.isOn(dateTime), isFalse);
         },
       );
     });
@@ -109,14 +109,14 @@ void main() {
         () {
           final startDateTime = DateTime(2022, 12, 1, 9, 30);
           final endDateTime = DateTime(2022, 12, 31, 21, 30);
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: startDateTime,
             endDate: endDateTime,
           );
-          expect(dateRange.includes(startDateTime), isTrue);
-          expect(dateRange.includes(endDateTime), isFalse);
+          expect(dateRanger.includes(startDateTime), isTrue);
+          expect(dateRanger.includes(endDateTime), isFalse);
           final dateTime = DateTime(2022, 12, 4, 11, 30);
-          expect(dateRange.includes(dateTime), isTrue);
+          expect(dateRanger.includes(dateTime), isTrue);
 
           final startDateRange = DateRange(startDate: startDateTime);
           expect(startDateRange.includes(dateTime), isTrue);
@@ -132,12 +132,12 @@ void main() {
         () {
           final beforeDateTime = DateTime(2022, 12, 1, 8);
           final afterDateTime = DateTime(2022, 12, 31, 21, 45);
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2022, 12, 31, 21, 30),
           );
-          expect(dateRange.includes(beforeDateTime), isFalse);
-          expect(dateRange.includes(afterDateTime), isFalse);
+          expect(dateRanger.includes(beforeDateTime), isFalse);
+          expect(dateRanger.includes(afterDateTime), isFalse);
 
           final startDateRange = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
@@ -162,16 +162,16 @@ void main() {
         'should return true if this finite DateRanger overlaps with another '
         'finite DateRanger',
         () {
-          final dateRange1 = DateRange(
+          final dateRanger1 = DateRange(
             startDate: DateTime(2022, 12, 4, 9, 15),
             endDate: DateTime(2022, 12, 4, 12, 15),
           );
-          final dateRange2 = DateRange(
+          final dateRanger2 = DateRange(
             startDate: DateTime(2022, 12, 4, 10, 15),
             endDate: DateTime(2022, 12, 4, 11, 15),
           );
-          expect(dateRange1.overlapsWith(dateRange2), isTrue);
-          expect(dateRange2.overlapsWith(dateRange1), isTrue);
+          expect(dateRanger1.overlapsWith(dateRanger2), isTrue);
+          expect(dateRanger2.overlapsWith(dateRanger1), isTrue);
         },
       );
 
@@ -179,21 +179,21 @@ void main() {
         'should return true if this infinite DateRanger overlaps with another '
         'infinite DateRanger',
         () {
-          final dateRange1 = DateRange(
+          final dateRanger1 = DateRange(
             endDate: DateTime(2022, 12, 4, 12, 15),
           );
-          final dateRange2 = DateRange(
+          final dateRanger2 = DateRange(
             startDate: DateTime(2022, 12, 4, 10, 15),
           );
-          expect(dateRange1.overlapsWith(dateRange2), isTrue);
-          expect(dateRange2.overlapsWith(dateRange1), isTrue);
+          expect(dateRanger1.overlapsWith(dateRanger2), isTrue);
+          expect(dateRanger2.overlapsWith(dateRanger1), isTrue);
 
           expect(DateRange.infinite.overlapsWith(DateRange.infinite), isTrue);
-          expect(DateRange.infinite.overlapsWith(dateRange1), isTrue);
-          expect(dateRange1.overlapsWith(DateRange.infinite), isTrue);
-          final dateRange3 = DateRange.fromDate(DateTime(2022, 12, 4));
-          expect(DateRange.infinite.overlapsWith(dateRange3), isTrue);
-          expect(dateRange3.overlapsWith(DateRange.infinite), isTrue);
+          expect(DateRange.infinite.overlapsWith(dateRanger1), isTrue);
+          expect(dateRanger1.overlapsWith(DateRange.infinite), isTrue);
+          final dateRanger3 = DateRange.fromDate(DateTime(2022, 12, 4));
+          expect(DateRange.infinite.overlapsWith(dateRanger3), isTrue);
+          expect(dateRanger3.overlapsWith(DateRange.infinite), isTrue);
         },
       );
 
@@ -201,10 +201,10 @@ void main() {
         'should return false if this finite DateRanger does not overlap with '
         'another finite DateRanger',
         () {
-          final dateRange1 = DateRange.fromDate(DateTime(2022, 12, 4));
-          final dateRange2 = DateRange.fromDate(DateTime(2022, 12, 5));
-          expect(dateRange1.overlapsWith(dateRange2), isFalse);
-          expect(dateRange2.overlapsWith(dateRange1), isFalse);
+          final dateRanger1 = DateRange.fromDate(DateTime(2022, 12, 4));
+          final dateRanger2 = DateRange.fromDate(DateTime(2022, 12, 5));
+          expect(dateRanger1.overlapsWith(dateRanger2), isFalse);
+          expect(dateRanger2.overlapsWith(dateRanger1), isFalse);
         },
       );
 
@@ -212,25 +212,25 @@ void main() {
         'should return false if this infinite DateRanger does not overlap with '
         'another infinite DateRanger',
         () {
-          final dateRange1 = DateRange(
+          final dateRanger1 = DateRange(
             startDate: DateTime(2022, 12, 4, 12, 15),
           );
-          final dateRange2 = DateRange(
+          final dateRanger2 = DateRange(
             endDate: DateTime(2022, 12, 4, 10, 15),
           );
-          expect(dateRange1.overlapsWith(dateRange2), isFalse);
-          expect(dateRange2.overlapsWith(dateRange1), isFalse);
+          expect(dateRanger1.overlapsWith(dateRanger2), isFalse);
+          expect(dateRanger2.overlapsWith(dateRanger1), isFalse);
         },
       );
     });
 
     group('.isFinite', () {
       test('should return true when this DateRanger is finite', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(dateRange.isFinite, isTrue);
+        expect(dateRanger.isFinite, isTrue);
       });
 
       test('should return false when this DateRanger is infinite', () {
@@ -264,11 +264,11 @@ void main() {
       });
 
       test('should return false when this DateRanger is finite', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(dateRange.isInfinite, isFalse);
+        expect(dateRanger.isInfinite, isFalse);
       });
     });
 
@@ -283,11 +283,11 @@ void main() {
       });
 
       test('should return false when this DateRanger has a finite start', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(dateRange.hasInfiniteStart, isFalse);
+        expect(dateRanger.hasInfiniteStart, isFalse);
 
         final startDateRange = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
@@ -307,11 +307,11 @@ void main() {
       });
 
       test('should return false when this DateRanger has a finite end', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 31, 21, 30),
         );
-        expect(dateRange.hasInfiniteEnd, isFalse);
+        expect(dateRanger.hasInfiniteEnd, isFalse);
 
         final endDateRange = DateRange(
           endDate: DateTime(2022, 12, 31, 21, 30),
@@ -358,24 +358,24 @@ void main() {
         'should return a textual range representation of a finite '
         'DateRanger with the same year',
         () {
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2022, 12, 31, 21, 30),
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2022)),
             'December 1 09:30 – December 31 21:30',
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2023)),
             'December 1, 2022 09:30 – December 31 21:30',
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
-            dateRange.textualDateTime(referenceDateTime: DateTime(2021)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2023)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2021)),
           );
           expect(
-            dateRange.textualDateTime(
+            dateRanger.textualDateTime(
               referenceDateTime: DateTime(2023),
               fullDateFormat: (format) => format.add_yMMMMEEEEd(),
               monthDayFormat: (format) => format.add_LLL().add_d(),
@@ -390,24 +390,24 @@ void main() {
         'should return a textual range representation of a finite '
         'DateRanger with the same year and day',
         () {
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2022, 12, 1, 21, 30),
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2022)),
             'December 1 09:30–21:30',
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2023)),
             'December 1, 2022 09:30–21:30',
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2023)),
-            dateRange.textualDateTime(referenceDateTime: DateTime(2021)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2023)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2021)),
           );
           expect(
-            dateRange.textualDateTime(
+            dateRanger.textualDateTime(
               referenceDateTime: DateTime(2022),
               monthDayFormat: (format) => format.add_d().add_LLL(),
               timeFormat: (format) => format.add_Hms(),
@@ -415,14 +415,14 @@ void main() {
             '1 Dec 09:30:00–21:30:00',
           );
           expect(
-            dateRange.textualDateTime(
+            dateRanger.textualDateTime(
               referenceDateTime: DateTime(2022),
               monthDayFormat: (format) => format.add_MMMMEEEEd(),
             ),
             'Thursday, December 1 09:30–21:30',
           );
           expect(
-            dateRange.textualDateTime(
+            dateRanger.textualDateTime(
               referenceDateTime: DateTime(2023),
               fullDateFormat: (format) => format.add_yMMMMEEEEd(),
             ),
@@ -435,22 +435,22 @@ void main() {
         'should return a textual range representation of a finite '
         'DateRanger with different years',
         () {
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
             endDate: DateTime(2023, 1, 12, 21, 30),
           );
           expect(
-            dateRange.textualDateTime(referenceDateTime: DateTime(2022)),
+            dateRanger.textualDateTime(referenceDateTime: DateTime(2022)),
             'December 1, 2022 09:30 – January 12, 2023 21:30',
           );
           expect(
-            dateRange.textualDateTime(
+            dateRanger.textualDateTime(
               fullDateFormat: (format) => format.add_yMd(),
             ),
             '12/1/2022 09:30 – 1/12/2023 21:30',
           );
           expect(
-            dateRange.textualDateTime(
+            dateRanger.textualDateTime(
               fullDateFormat: (format) => format.add_yMMMMEEEEd(),
             ),
             'Thursday, December 1, 2022 09:30 – '
@@ -486,11 +486,11 @@ void main() {
 
     group('.textualTime', () {
       test('should return the textual time range of a finite DateRanger', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
           endDate: DateTime(2022, 12, 1, 21, 30),
         );
-        expect(dateRange.textualTime, '09:30–21:30');
+        expect(dateRanger.textualTime, '09:30–21:30');
 
         final multiYearDateRange = DateRange(
           startDate: DateTime(2022, 12, 1, 9, 30),
@@ -502,15 +502,15 @@ void main() {
       test(
         'should return the textual local time range of a UTC DateRanger',
         () {
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime.utc(2022, 12, 1, 9, 30),
             endDate: DateTime.utc(2022, 12, 1, 21, 45),
           );
-          final startDate = dateRange.startDate!.toLocal();
-          final endDate = dateRange.endDate!.toLocal();
+          final startDate = dateRanger.startDate!.toLocal();
+          final endDate = dateRanger.endDate!.toLocal();
           String padTime(int time) => '$time'.padLeft(2, '0');
           expect(
-            dateRange.textualTime,
+            dateRanger.textualTime,
             '${padTime(startDate.hour)}:${padTime(startDate.minute)}–'
             '${padTime(endDate.hour)}:${padTime(endDate.minute)}',
           );
@@ -520,10 +520,10 @@ void main() {
       test(
         'should return the textual time range of an infinite DateRanger',
         () {
-          final dateRange = DateRange(
+          final dateRanger = DateRange(
             startDate: DateTime(2022, 12, 1, 9, 30),
           );
-          expect(dateRange.textualTime, '09:30 – null');
+          expect(dateRanger.textualTime, '09:30 – null');
 
           final multiYearDateRange = DateRange(
             endDate: DateTime(2023, 1, 12, 21, 30),
@@ -537,11 +537,11 @@ void main() {
 
     group('.hoursSpan', () {
       test('should return a Map of the time span of this DateRanger', () {
-        final dateRange = DateRange(
+        final dateRanger = DateRange(
           startDate: DateTime(2022, 12, 4, 9, 30),
           endDate: DateTime(2022, 12, 4, 13, 15),
         );
-        expect(dateRange.hoursSpan, {
+        expect(dateRanger.hoursSpan, {
           const TimeOfDay(hour: 09, minute: 0): const Duration(minutes: 30),
           const TimeOfDay(hour: 10, minute: 0): const Duration(hours: 1),
           const TimeOfDay(hour: 11, minute: 0): const Duration(hours: 1),
@@ -574,8 +574,8 @@ void main() {
 
     group('.dateTimeList()', () {
       test('should return a DateTime list included in this DateRanger', () {
-        final dateRange = DateRange.fromDate(DateTime(2022, 12, 4));
-        expect(dateRange.dateTimeList(interval: const Duration(hours: 8)), [
+        final dateRanger = DateRange.fromDate(DateTime(2022, 12, 4));
+        expect(dateRanger.dateTimeList(interval: const Duration(hours: 8)), [
           DateTime(2022, 12, 4),
           DateTime(2022, 12, 4, 8),
           DateTime(2022, 12, 4, 16),


### PR DESCRIPTION
Variables of type `DateRanger` and `DateRangeItem` had inconsistent names across the app. This PR consistently renames all members to their appropriate naming.

Furthermore, it replaces declaracions inferring the `DateRange` type with its supertype `DateRanger` that is being consumed in tests, providing more visibility on what is tested.