### PR TITLE
refactor(booking_collection): rewrite methods using a `DateRanger` param

### DIFF
--- a/lib/src/model/cabin_collection.dart
+++ b/lib/src/model/cabin_collection.dart
@@ -131,14 +131,10 @@ class CabinCollection extends WritableManager<Set<Cabin>>
     return count;
   }
 
-  Duration totalOccupiedDuration({DateTime? dateTime, DateRanger? dateRange}) {
+  Duration totalOccupiedDuration([DateRanger? dateRanger]) {
     var duration = Duration.zero;
-
     for (final cabin in cabins) {
-      duration += cabin.bookingCollection.occupiedDuration(
-        dateTime: dateTime,
-        dateRange: dateRange,
-      );
+      duration += cabin.bookingCollection.occupiedDuration(dateRanger);
     }
 
     return duration;

--- a/lib/widgets/layout/scrollable_time_table.dart
+++ b/lib/widgets/layout/scrollable_time_table.dart
@@ -1,5 +1,6 @@
 import 'package:cabin_booking/constants.dart';
 import 'package:cabin_booking/model.dart';
+import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:cabin_booking/widgets/booking/booking_preview_panel_overlay.dart';
 import 'package:cabin_booking/widgets/booking/bookings_table.dart';
 import 'package:cabin_booking/widgets/cabin/cabin_icon.dart';
@@ -86,6 +87,11 @@ class _ScrollablePanelOverlayTimeTableState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final dateRange = DateRange(
+      startDate: widget.dateTime.addLocalTimeOfDay(kTimeTableStartTime),
+      endDate: widget.dateTime.addLocalTimeOfDay(kTimeTableEndTime),
+    );
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final bookingStackWidth = _stackWidth(constraints.maxWidth);
@@ -110,12 +116,8 @@ class _ScrollablePanelOverlayTimeTableState
                           width: bookingStackWidth,
                           child: CabinIcon.progress(
                             number: cabin.number,
-                            progress:
-                                cabin.bookingCollection.occupancyPercentOn(
-                              widget.dateTime,
-                              startTime: kTimeTableStartTime,
-                              endTime: kTimeTableEndTime,
-                            ),
+                            progress: cabin.bookingCollection
+                                .occupancyPercentOn(dateRange),
                           ),
                         ),
                     ],

--- a/lib/widgets/school_year/school_years_table.dart
+++ b/lib/widgets/school_year/school_years_table.dart
@@ -28,9 +28,8 @@ class SchoolYearsTable extends StatelessWidget {
                 bookingsCount: cabinCollection.bookingsCountBetween(schoolYear),
                 recurringBookingsCount:
                     cabinCollection.recurringBookingsCountBetween(schoolYear),
-                occupiedDuration: cabinCollection.totalOccupiedDuration(
-                  dateRange: schoolYear,
-                ),
+                occupiedDuration:
+                    cabinCollection.totalOccupiedDuration(schoolYear),
                 occupiedDurationPerWeek:
                     cabinCollection.occupiedDurationPerWeek(schoolYear)
                       ..fillEmptyKeyValues(

--- a/test/model/booking_collection_test.dart
+++ b/test/model/booking_collection_test.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
 
 import 'package:cabin_booking/model.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -137,9 +136,11 @@ void main() {
           final emptyBookingCollection = BookingCollection();
           expect(emptyBookingCollection.occupiedDuration(), Duration.zero);
           expect(
-            emptyBookingCollection.occupiedDuration(
-              dateRange: DateRange.today(),
-            ),
+            emptyBookingCollection.occupiedDuration(DateRange.infinite),
+            Duration.zero,
+          );
+          expect(
+            emptyBookingCollection.occupiedDuration(DateRange.today()),
             Duration.zero,
           );
         },
@@ -175,18 +176,18 @@ void main() {
         const totalDuration = Duration(hours: 16);
         expect(bookingCollection.occupiedDuration(), totalDuration);
         expect(
-          bookingCollection.occupiedDuration(dateRange: DateRange.infinite),
+          bookingCollection.occupiedDuration(DateRange.infinite),
           totalDuration,
         );
         expect(
           bookingCollection.occupiedDuration(
-            dateTime: DateTime.utc(2022, 12, 4),
+            DateRange.fromDate(DateTime.utc(2022, 12, 4)),
           ),
           const Duration(hours: 1, minutes: 30),
         );
         expect(
           bookingCollection.occupiedDuration(
-            dateRange: DateRange(
+            DateRange(
               startDate: DateTime.utc(2022, 12, 5, 20, 30),
               endDate: DateTime.utc(2022, 12, 5, 21),
             ),
@@ -203,12 +204,9 @@ void main() {
         'BookingCollection',
         () {
           final emptyBookingCollection = BookingCollection();
+          expect(emptyBookingCollection.occupancyPercentOn(), 0);
           expect(
-            emptyBookingCollection.occupancyPercentOn(
-              DateTime.now(),
-              startTime: const TimeOfDay(hour: 9, minute: 0),
-              endTime: const TimeOfDay(hour: 10, minute: 0),
-            ),
+            emptyBookingCollection.occupancyPercentOn(DateRange.today()),
             0,
           );
         },
@@ -246,17 +244,16 @@ void main() {
           );
           expect(
             bookingCollection.occupancyPercentOn(
-              DateTime.utc(2022, 12, 4),
-              startTime: const TimeOfDay(hour: 0, minute: 0),
-              endTime: const TimeOfDay(hour: 23, minute: 59),
+              DateRange.fromDate(DateTime.utc(2022, 12, 4)),
             ),
             closeTo(0.063, 0.001),
           );
           expect(
             bookingCollection.occupancyPercentOn(
-              DateTime.utc(2022, 12, 5),
-              startTime: const TimeOfDay(hour: 20, minute: 30),
-              endTime: const TimeOfDay(hour: 21, minute: 0),
+              DateRange(
+                startDate: DateTime.utc(2022, 12, 5, 20, 30),
+                endDate: DateTime.utc(2022, 12, 5, 21),
+              ),
             ),
             // TODO(albertms10): fix out of bounds ratio.
             2,


### PR DESCRIPTION
After #132, the `DateRanger` mixin had a more comprehensible set of methods to operate with. Thus, this PR takes advantage of it by consistently using a `DateRanger` object for date operations.