### PR TITLE
feat(scrollable_time_table): add tappable message to navigate to the Cabins page

### DIFF
--- a/lib/widgets/layout/scrollable_time_table.dart
+++ b/lib/widgets/layout/scrollable_time_table.dart
@@ -4,7 +4,9 @@ import 'package:cabin_booking/utils/date_time_extension.dart';
 import 'package:cabin_booking/widgets/booking/booking_preview_panel_overlay.dart';
 import 'package:cabin_booking/widgets/booking/bookings_table.dart';
 import 'package:cabin_booking/widgets/cabin/cabin_icon.dart';
+import 'package:cabin_booking/widgets/layout/centered_icon_message.dart';
 import 'package:cabin_booking/widgets/layout/time_column.dart';
+import 'package:cabin_booking/widgets/pages/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:horizontal_data_table/horizontal_data_table.dart';
@@ -25,12 +27,15 @@ class ScrollableTimeTable extends StatelessWidget {
           child: Consumer2<DayHandler, CabinCollection>(
             builder: (context, dayHandler, cabinCollection, child) {
               if (cabinCollection.cabins.isEmpty) {
-                return Center(
-                  child: Text(
-                    AppLocalizations.of(context)!.noCabins,
-                    style: theme.textTheme.headlineSmall
-                        ?.copyWith(color: Colors.grey[600]),
-                    textAlign: TextAlign.center,
+                return Material(
+                  child: InkWell(
+                    onTap: () {
+                      HomePage.of(context)?.setNavigationPage(AppPage.cabins);
+                    },
+                    child: CenteredIconMessage(
+                      icon: Icons.sensor_door,
+                      message: AppLocalizations.of(context)!.noCabinsMessage,
+                    ),
                   ),
                 );
               }


### PR DESCRIPTION
To help users add their first cabin, tapping the _Add a cabin to begin_ message will navigate to the Cabins page.