### PR TITLE
ci(analysis): run workflow on all paths

### DIFF
--- a/.github/workflows/analysis-ci.yaml
+++ b/.github/workflows/analysis-ci.yaml
@@ -3,40 +3,42 @@ name: Analysis CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - ".github/dependabot.yaml"
-      - ".github/workflows/build-cd.yaml"
-      - ".github/workflows/scorecards-analysis.yaml"
-      - ".vscode/**"
-      - "android/**"
-      - "docs/**"
-      - "ios/**"
-      - "macos/**"
-      - "windows/**"
-      - "**.md"
-      - ".gitattributes"
-      - ".gitignore"
-      - "CODEOWNERS"
-      - "LICENSE"
+  # Ignore paths with no code to analyze.
+  # Disabled for OpenSSF scoring purposes (all commit pushes MUST be analyzed).
+  # paths-ignore:
+  #   - ".github/dependabot.yaml"
+  #   - ".github/workflows/build-cd.yaml"
+  #   - ".github/workflows/scorecards-analysis.yaml"
+  #   - ".vscode/**"
+  #   - "android/**"
+  #   - "docs/**"
+  #   - "ios/**"
+  #   - "macos/**"
+  #   - "windows/**"
+  #   - "**.md"
+  #   - ".gitattributes"
+  #   - ".gitignore"
+  #   - "CODEOWNERS"
+  #   - "LICENSE"
 
   pull_request:
     branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
-    paths-ignore:
-      - ".github/dependabot.yaml"
-      - ".github/workflows/build-cd.yaml"
-      - ".github/workflows/scorecards-analysis.yaml"
-      - ".vscode/**"
-      - "android/**"
-      - "docs/**"
-      - "ios/**"
-      - "macos/**"
-      - "windows/**"
-      - "**.md"
-      - ".gitattributes"
-      - ".gitignore"
-      - "CODEOWNERS"
-      - "LICENSE"
+  # paths-ignore:
+  #   - ".github/dependabot.yaml"
+  #   - ".github/workflows/build-cd.yaml"
+  #   - ".github/workflows/scorecards-analysis.yaml"
+  #   - ".vscode/**"
+  #   - "android/**"
+  #   - "docs/**"
+  #   - "ios/**"
+  #   - "macos/**"
+  #   - "windows/**"
+  #   - "**.md"
+  #   - ".gitattributes"
+  #   - ".gitignore"
+  #   - "CODEOWNERS"
+  #   - "LICENSE"
 
   release:
     types: [published]


### PR DESCRIPTION
This PR changes the Analysis CI workflow to run on all pushed commits, indistinct of their changed paths. https://github.com/albertms10/cabin_booking/security/code-scanning/7 needs all required CI tests to be met before a change is accepted.