### PR TITLE
fix(color_extension): take `minOpacity` into account when mapping opacity thresholds

### DIFF
--- a/lib/utils/color_extension.dart
+++ b/lib/utils/color_extension.dart
@@ -17,7 +17,7 @@ extension ColorExtension on Color {
   /// ```dart
   /// const color = Colors.blue;
   /// const thresholds = {
-  ///   1: Color(0x332196f3),
+  ///   1: Color(0x002196f3),
   ///   4: Color(0x552196f3),
   ///   8: Color(0xaa2196f3),
   ///   12: Color(0xff2196f3),

--- a/lib/utils/color_extension.dart
+++ b/lib/utils/color_extension.dart
@@ -29,7 +29,7 @@ extension ColorExtension on Color {
   Map<int, Color> opacityThresholds({
     required int highestValue,
     required int samples,
-    double minOpacity = 0.2,
+    double minOpacity = 0,
   }) {
     if (samples < 1) {
       throw RangeError.range(samples, 1, null, 'samples');

--- a/lib/utils/color_extension.dart
+++ b/lib/utils/color_extension.dart
@@ -31,8 +31,11 @@ extension ColorExtension on Color {
     required int samples,
     double minOpacity = 0.2,
   }) {
-    if (samples <= 0) {
+    if (samples < 1) {
       throw RangeError.range(samples, 1, null, 'samples');
+    }
+    if (minOpacity < 0 || minOpacity >= 1) {
+      throw RangeError.range(minOpacity, 0, 1, 'minOpacity');
     }
 
     final colorMap = SplayTreeMap<int, Color>.of({
@@ -44,10 +47,17 @@ extension ColorExtension on Color {
 
       if (currentValue <= 1) continue;
 
-      final colorValue = currentValue.map(inMax: highestValue).toDouble();
+      final colorValue =
+          currentValue.map(inMax: highestValue, outMin: minOpacity).toDouble();
 
       if (!colorMap.containsKey(currentValue)) {
-        colorMap.addAll({currentValue: withOpacity(colorValue)});
+        colorMap.addAll({
+          currentValue: withOpacity(
+            // In some edge cases, `colorValue` might be slightly greater than 1
+            // due to a practically negligible error in the `num.map` operation.
+            colorValue >= 1 ? 1 : colorValue,
+          ),
+        });
       }
     }
 

--- a/lib/widgets/booking/bookings_heat_map_calendar.dart
+++ b/lib/widgets/booking/bookings_heat_map_calendar.dart
@@ -31,6 +31,7 @@ class BookingsHeatMapCalendar extends StatelessWidget {
                           highestValue:
                               cabinCollection.mostBookedDayEntry?.value ?? 1,
                           samples: 8,
+                          minOpacity: 0.2,
                         ),
                 firstWeekDay: DateTime.monday,
                 onDayTap: onDayTap == null

--- a/lib/widgets/standalone/heat_map_calendar/heat_map_legend.dart
+++ b/lib/widgets/standalone/heat_map_calendar/heat_map_legend.dart
@@ -26,8 +26,11 @@ class HeatMapLegend extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final colorThresholds =
-        color.opacityThresholds(highestValue: samples, samples: samples - 1);
+    final colorThresholds = color.opacityThresholds(
+      highestValue: samples,
+      samples: samples - 1,
+      minOpacity: 0.2,
+    );
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/test/utils/color_extension_test.dart
+++ b/test/utils/color_extension_test.dart
@@ -8,7 +8,7 @@ void main() {
       test('should return a valid threshold to color Map', () {
         const color = Colors.blue;
         const thresholds = {
-          1: Color(0x332196f3),
+          1: Color(0x002196f3),
           4: Color(0x552196f3),
           8: Color(0xaa2196f3),
           12: Color(0xff2196f3),
@@ -19,13 +19,64 @@ void main() {
         );
       });
 
+      test(
+        'should return a valid threshold to color Map with custom minOpacity',
+        () {
+          const color = Colors.red;
+          const thresholds = {
+            1: Color(0x40f44336),
+            2: Color(0x70f44336),
+            4: Color(0x9ff44336),
+            6: Color(0xcff44336),
+            8: Color(0xfff44336),
+          };
+          expect(
+            color.opacityThresholds(
+              highestValue: 8,
+              samples: 4,
+              minOpacity: 0.25,
+            ),
+            thresholds,
+          );
+        },
+      );
+
       test('should throw a RangeError if samples is not greater than zero', () {
         const color = Colors.blue;
         expect(
+          () => color.opacityThresholds(highestValue: 12, samples: 0),
+          throwsA(_samplesRangeErrorPredicate),
+        );
+        expect(
           () => color.opacityThresholds(highestValue: 12, samples: -1),
-          throwsRangeError,
+          throwsA(_samplesRangeErrorPredicate),
+        );
+      });
+
+      test('should throw a RangeError if minOpacity is out of bounds', () {
+        const color = Colors.blue;
+        expect(
+          () => color.opacityThresholds(
+            highestValue: 12,
+            samples: 3,
+            minOpacity: -0.1,
+          ),
+          throwsA(_minOpacityRangeErrorPredicate),
+        );
+        expect(
+          () => color.opacityThresholds(
+            highestValue: 12,
+            samples: 3,
+            minOpacity: 1.01,
+          ),
+          throwsA(_minOpacityRangeErrorPredicate),
         );
       });
     });
   });
 }
+
+final _samplesRangeErrorPredicate =
+    predicate((e) => e is RangeError && e.name == 'samples');
+final _minOpacityRangeErrorPredicate =
+    predicate((e) => e is RangeError && e.name == 'minOpacity');


### PR DESCRIPTION
This PR aims to take `minOpacity` into account when mapping values in the `ColorExtension.opacityThresholds` method.

Previously, opacity thresholds were mapped ignoring `minOpacity`, assuming the minimum value was always 0. Now, instead of $0 \leq t \leq 1$, they are proportionally output in the range `minOpacity` $\leq t \leq 1$.